### PR TITLE
Feature/15 research

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,7 +11,6 @@ import 'package:mood_trend_flutter/presentation/components/dialog.dart';
 import 'package:mood_trend_flutter/presentation/components/loading.dart';
 import 'package:mood_trend_flutter/presentation/components/snackbars.dart';
 import 'package:mood_trend_flutter/presentation/root_page.dart';
-import 'package:mood_trend_flutter/utils/app_colors.dart';
 import 'package:mood_trend_flutter/utils/constants.dart';
 import 'package:package_info/package_info.dart';
 
@@ -47,12 +46,7 @@ class App extends ConsumerWidget {
       title: 'Mood Trend',
       theme: ThemeData(
         useMaterial3: true,
-        colorSchemeSeed: AppColors.green,
-        textTheme: TextTheme(
-          bodyLarge: TextStyle(color: AppColors.grey),
-          bodyMedium: TextStyle(color: AppColors.grey),
-          bodySmall: TextStyle(color: AppColors.grey),
-        ),
+        colorSchemeSeed: Colors.greenAccent,
         sliderTheme: SliderThemeData(
           overlayShape: SliderComponentShape.noOverlay,
         ),

--- a/lib/presentation/components/anchor_text.dart
+++ b/lib/presentation/components/anchor_text.dart
@@ -9,7 +9,7 @@ class AnchorText extends StatelessWidget {
 
   static TextStyle anchorStyleText(BuildContext context) => TextStyle(
         decoration: TextDecoration.underline,
-        color: AppColors.grey,
+        color: Theme.of(context).colorScheme.outline,
       );
 
   @override

--- a/lib/presentation/research/research_1.dart
+++ b/lib/presentation/research/research_1.dart
@@ -1,5 +1,3 @@
-import 'dart:collection';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -99,11 +97,11 @@ class _MyWidgetState extends ConsumerState<InputModal> with ErrorHandlerMixin {
               Row(
                 children: [
                   const Text(
-                    '気分値 ',
+                    '気分値',
                     style: TextStyle(fontSize: 24),
                   ),
                   SizedBox(
-                    width: 50,
+                    width: 75,
                     child: Padding(
                       padding: const EdgeInsets.fromLTRB(0, 0, 0, 15),
                       child: Center(
@@ -134,18 +132,23 @@ class _MyWidgetState extends ConsumerState<InputModal> with ErrorHandlerMixin {
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              const SizedBox(width: 72),
+              const SizedBox(width: 80),
               Row(
                 children: [
                   const Text(
-                    '予定数 ',
+                    '予定数',
                     style: TextStyle(fontSize: 24),
                   ),
-                  Padding(
-                    padding: const EdgeInsets.fromLTRB(0, 0, 0, 15),
-                    child: Text(
-                      _value.toInt().toString(),
-                      style: const TextStyle(fontSize: 52),
+                  SizedBox(
+                    width: 75,
+                    child: Padding(
+                      padding: const EdgeInsets.fromLTRB(0, 0, 0, 15),
+                      child: Center(
+                        child: Text(
+                          _value.toInt().toString(),
+                          style: const TextStyle(fontSize: 52),
+                        ),
+                      ),
                     ),
                   ),
                 ],

--- a/lib/presentation/research/research_1.dart
+++ b/lib/presentation/research/research_1.dart
@@ -41,12 +41,12 @@ class InputModal extends ConsumerStatefulWidget {
 }
 
 class _MyWidgetState extends ConsumerState<InputModal> with ErrorHandlerMixin {
-  double _value = 0.0;
+  double _plannedValue = 0.0;
   DateTime date = DateTime.now();
 
   int moodNum = 1;
   void _changeSlider(double e) => setState(() {
-        _value = e;
+        _plannedValue = e;
       });
   double _moodValue = 1.0;
   @override
@@ -137,10 +137,10 @@ class _MyWidgetState extends ConsumerState<InputModal> with ErrorHandlerMixin {
           Padding(
             padding: const EdgeInsets.fromLTRB(56, 32, 56, 0),
             child: Slider(
-              label: _value.toInt().toString(),
+              label: _plannedValue.toInt().toString(),
               min: 0,
               max: 16,
-              value: _value,
+              value: _plannedValue,
               activeColor: Colors.green,
               inactiveColor: Colors.grey,
               divisions: 16,
@@ -163,7 +163,7 @@ class _MyWidgetState extends ConsumerState<InputModal> with ErrorHandlerMixin {
                       padding: const EdgeInsets.fromLTRB(0, 0, 0, 15),
                       child: Center(
                         child: Text(
-                          _value.toInt().toString(),
+                          _plannedValue.toInt().toString(),
                           style: const TextStyle(fontSize: 52),
                         ),
                       ),
@@ -181,9 +181,9 @@ class _MyWidgetState extends ConsumerState<InputModal> with ErrorHandlerMixin {
                       action: () async {
                         // mood_points コレクションにドキュメントを追加
                         await ref.read(moodPointRepositoryProvider).add(
-                              point: 2,
-                              plannedVolume: 3,
-                              moodDate: DateTime.now(),
+                              point: _moodValue.toInt(),
+                              plannedVolume: _plannedValue.toInt(),
+                              moodDate: date,
                             );
 
                         // モーダルを閉じる

--- a/lib/presentation/research/research_1.dart
+++ b/lib/presentation/research/research_1.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
 
 import '../../infrastructure/firebase/mood_point_repository.dart';
 import '../mixin/error_handler_mixin.dart';
@@ -76,8 +77,7 @@ class _MyWidgetState extends ConsumerState<InputModal> with ErrorHandlerMixin {
               }
             },
             icon: const Icon(Icons.calendar_month),
-            label: Text(
-                "${date.year.toString()}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}"),
+            label: Text(DateFormat('yyyy-MM-dd').format(date)),
           ),
           Padding(
             padding: const EdgeInsets.fromLTRB(56, 48, 56, 0),

--- a/lib/presentation/research/research_1.dart
+++ b/lib/presentation/research/research_1.dart
@@ -9,14 +9,18 @@ class Research1 extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
     return Scaffold(
       appBar: AppBar(
         title: const Text('Mood Trend'),
       ),
       floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
       floatingActionButton: FloatingActionButton(
+        backgroundColor: colors.primary,
+        foregroundColor: colors.onPrimary,
         onPressed: () {
           showModalBottomSheet(
+            backgroundColor: colors.background,
             isScrollControlled: true,
             context: context,
             builder: (context) {
@@ -56,7 +60,7 @@ class _MyWidgetState extends ConsumerState<InputModal> with ErrorHandlerMixin {
       child: Center(
         child: Column(mainAxisAlignment: MainAxisAlignment.start, children: [
           const SizedBox(
-            height: 8,
+            height: 16,
           ),
           TextButton.icon(
             onPressed: () async {
@@ -77,14 +81,12 @@ class _MyWidgetState extends ConsumerState<InputModal> with ErrorHandlerMixin {
                 "${date.year.toString()}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}"),
           ),
           Padding(
-            padding: const EdgeInsets.fromLTRB(56, 32, 56, 0),
+            padding: const EdgeInsets.fromLTRB(56, 48, 56, 0),
             child: Slider(
               value: _moodValue,
               min: -5.0,
               max: 5.0,
               divisions: 10,
-              activeColor: Colors.green,
-              inactiveColor: Colors.grey,
               onChangeStart: (value) {
                 if (value == 0.0) {
                   setState(() {
@@ -135,14 +137,12 @@ class _MyWidgetState extends ConsumerState<InputModal> with ErrorHandlerMixin {
             ],
           ),
           Padding(
-            padding: const EdgeInsets.fromLTRB(56, 32, 56, 0),
+            padding: const EdgeInsets.fromLTRB(56, 24, 56, 0),
             child: Slider(
               label: _plannedValue.toInt().toString(),
               min: 0,
               max: 16,
               value: _plannedValue,
-              activeColor: Colors.green,
-              inactiveColor: Colors.grey,
               divisions: 16,
               onChanged: _changeSlider,
             ),
@@ -193,7 +193,10 @@ class _MyWidgetState extends ConsumerState<InputModal> with ErrorHandlerMixin {
                       successMessage: '気分値と予定数の登録が完了しました',
                     );
                   },
-                  child: const Text('保存'),
+                  child: const Text(
+                    '保存',
+                    style: TextStyle(fontWeight: FontWeight.bold),
+                  ),
                 ),
               ),
             ],

--- a/lib/presentation/research/research_1.dart
+++ b/lib/presentation/research/research_1.dart
@@ -14,7 +14,6 @@ class Research1 extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Mood Trend'),
       ),
-      floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
       floatingActionButton: FloatingActionButton(
         backgroundColor: colors.primary,
         foregroundColor: colors.onPrimary,
@@ -56,7 +55,7 @@ class _MyWidgetState extends ConsumerState<InputModal> with ErrorHandlerMixin {
   @override
   Widget build(BuildContext context) {
     return SizedBox(
-      height: 400,
+      height: 410,
       child: Center(
         child: Column(mainAxisAlignment: MainAxisAlignment.start, children: [
           const SizedBox(

--- a/lib/presentation/research/research_1.dart
+++ b/lib/presentation/research/research_1.dart
@@ -42,6 +42,7 @@ class InputModal extends ConsumerStatefulWidget {
 
 class _MyWidgetState extends ConsumerState<InputModal> with ErrorHandlerMixin {
   double _value = 0.0;
+  DateTime date = DateTime.now();
 
   int moodNum = 1;
   void _changeSlider(double e) => setState(() {
@@ -51,12 +52,29 @@ class _MyWidgetState extends ConsumerState<InputModal> with ErrorHandlerMixin {
   @override
   Widget build(BuildContext context) {
     return SizedBox(
-      height: 350,
+      height: 400,
       child: Center(
         child: Column(mainAxisAlignment: MainAxisAlignment.start, children: [
-          const Padding(
-            padding: EdgeInsets.all(8.0),
-            child: Text('2023/11/1'),
+          const SizedBox(
+            height: 8,
+          ),
+          TextButton.icon(
+            onPressed: () async {
+              final selectedDate = await showDatePicker(
+                context: context,
+                initialDate: date,
+                firstDate: DateTime(2000),
+                lastDate: DateTime.now(),
+              );
+              if (selectedDate != null) {
+                setState(() {
+                  date = selectedDate;
+                });
+              }
+            },
+            icon: const Icon(Icons.calendar_month),
+            label: Text(
+                "${date.year.toString()}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}"),
           ),
           Padding(
             padding: const EdgeInsets.fromLTRB(56, 32, 56, 0),

--- a/lib/presentation/signin_page.dart
+++ b/lib/presentation/signin_page.dart
@@ -15,14 +15,17 @@ class SigninPage extends ConsumerWidget with ErrorHandlerMixin {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final colors = Theme.of(context).colorScheme;
     return Scaffold(
       body: Container(
         width: double.infinity,
         decoration: BoxDecoration(
           gradient: LinearGradient(
             colors: [
-              AppColors.green,
-              AppColors.yellow,
+              colors.primary,
+              colors.primaryContainer,
+              // AppColors.green
+              // AppColors.yellow,
             ],
             begin: Alignment.topCenter,
             end: Alignment.bottomCenter,
@@ -66,7 +69,8 @@ class SigninPage extends ConsumerWidget with ErrorHandlerMixin {
                   textAlign: TextAlign.center,
                   text: TextSpan(
                     style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                          color: Theme.of(context).colorScheme.surface,
+                          // color: Theme.of(context).colorScheme.surface,
+                          color: colors.surface,
                           fontWeight: FontWeight.bold,
                         ),
                     children: [
@@ -80,7 +84,7 @@ class SigninPage extends ConsumerWidget with ErrorHandlerMixin {
                       ),
                       TextSpan(
                         text: ' と ',
-                        style: TextStyle(color: AppColors.grey),
+                        style: TextStyle(color: colors.outline),
                       ),
                       TextSpan(
                         text: 'プライバシーポリシー',
@@ -92,7 +96,7 @@ class SigninPage extends ConsumerWidget with ErrorHandlerMixin {
                       ),
                       TextSpan(
                         text: ' に\n同意の上ご利用ください',
-                        style: TextStyle(color: AppColors.grey),
+                        style: TextStyle(color: colors.outline),
                       ),
                     ],
                   ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -438,7 +438,7 @@ packages:
     source: hosted
     version: "4.0.2"
   intl:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: intl
       sha256: a3715e3bc90294e971cb7dc063fbf3cd9ee0ebf8604ffeafabd9e6f16abbdbe6

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   gap: ^3.0.1
   url_launcher: ^6.1.14
   hexcolor: ^3.0.1
+  intl: ^0.18.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## [Design Doc] 気分値と予定数の登録 #15

close #15

## 変更点
UIの微調整
日付変更の実装
気分値と予定量と日付の登録

### やったこと
気分値と予定量の表示の位置を整えた
showDatePickerを使って日付選択機能を実装
Firebaseに気分値と予定量と日付を登録

### やってないこと
色の設定
同じ日付で２回データを入力できないようにする処理の実装

## スクリーンショット（該当する場合）
色変更前

https://github.com/Mood-Trend/mood-trend-flutter/assets/66543967/1a4bde34-227f-4cf3-bbc6-e7d1afad37ab

色変更後

https://github.com/Mood-Trend/mood-trend-flutter/assets/66543967/6251622e-d366-4be4-94a1-92dcef16ac34

## レビューのポイント

- 特にチェックしてほしいエリア
- 懸念点
2000まで遡れるようにしたが、グラフ表示時に問題ないか
- フィードバックや提案を求めるエリア
Material3準拠で色を指定したいが、ThemeData内でのTextThemeなどの指定には使えない（まだテーマカラーを変更していないcontextを使うことになるので）
この時どうすれば良いかわからず、一旦各所で色を
```
final colors = Theme.of(context).colorScheme;
...
backgroundColor: colors.primary,
```
のように指定している。
良い方法を知りたいです。