### PR TITLE
Feature/16 issue

### DIFF
--- a/lib/presentation/home_page.dart
+++ b/lib/presentation/home_page.dart
@@ -33,15 +33,7 @@ class HomePage extends ConsumerWidget {
       appBar: AppBar(
         actions: [
           IconButton(
-            onPressed: () {
-              showModalBottomSheet(
-                isScrollControlled: true,
-                context: context,
-                builder: (context) {
-                  return const SettingModal();
-                },
-              );
-            },
+            onPressed: () => PageNavigator.push(context, const SettingPage()),
             icon: const Icon(Icons.settings),
           ),
         ],

--- a/lib/presentation/home_page.dart
+++ b/lib/presentation/home_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mood_trend_flutter/domain/mood_point.dart';
 import 'package:mood_trend_flutter/presentation/components/async_value_handler.dart';
 import 'package:mood_trend_flutter/presentation/components/loading.dart';
+import 'package:mood_trend_flutter/presentation/setting_page.dart';
 import 'package:mood_trend_flutter/utils/page_navigator.dart';
 import 'package:syncfusion_flutter_charts/charts.dart';
 
@@ -32,9 +33,14 @@ class HomePage extends ConsumerWidget {
       appBar: AppBar(
         actions: [
           IconButton(
-            onPressed: () async {
-              // TODO: 設定画面を作成する
-              await PageNavigator.push(context, const SizedBox());
+            onPressed: () {
+              showModalBottomSheet(
+                isScrollControlled: true,
+                context: context,
+                builder: (context) {
+                  return const SettingModal();
+                },
+              );
             },
             icon: const Icon(Icons.settings),
           ),

--- a/lib/presentation/setting_page.dart
+++ b/lib/presentation/setting_page.dart
@@ -17,7 +17,7 @@ class _SettingModalState extends State<SettingModal> {
         elevation: 0,
         backgroundColor: Colors.transparent,
         centerTitle: true,
-        title: Text("設定"),
+        title: const Text("設定"),
         leading: IconButton(
           onPressed: () {
             Navigator.of(context).pop();
@@ -28,46 +28,52 @@ class _SettingModalState extends State<SettingModal> {
       body: Column(
         mainAxisAlignment: MainAxisAlignment.start,
         children: [
-          Padding(
-            padding: const EdgeInsets.all(16.0),
+          const Padding(
+            padding: EdgeInsets.all(16.0),
             child: Row(
               children: [
                 Text("編集"),
               ],
             ),
           ),
-          Container(
-            color: colors.onPrimary,
-            width: double.infinity,
-            child: Padding(
-              padding: const EdgeInsets.all(16.0),
-              child: Text(
-                "症状ワークシート",
-                style: TextStyle(fontSize: 16),
+          GestureDetector(
+            onTap: () {},
+            child: Container(
+              color: colors.onPrimary,
+              width: double.infinity,
+              child: const Padding(
+                padding: EdgeInsets.all(16.0),
+                child: Text(
+                  "症状ワークシート",
+                  style: TextStyle(fontSize: 16),
+                ),
               ),
             ),
           ),
-          Padding(
-            padding: const EdgeInsets.all(16.0),
+          const Padding(
+            padding: EdgeInsets.all(16.0),
             child: Row(
               children: [
                 Text("サポート"),
               ],
             ),
           ),
-          Container(
-            color: colors.onPrimary,
-            width: double.infinity,
-            child: Padding(
-              padding: const EdgeInsets.all(16.0),
-              child: Text(
-                "お問い合わせ",
-                style: TextStyle(fontSize: 16),
+          GestureDetector(
+            onTap: () {},
+            child: Container(
+              color: colors.onPrimary,
+              width: double.infinity,
+              child: const Padding(
+                padding: EdgeInsets.all(16.0),
+                child: Text(
+                  "お問い合わせ",
+                  style: TextStyle(fontSize: 16),
+                ),
               ),
             ),
           ),
-          Padding(
-            padding: const EdgeInsets.all(16.0),
+          const Padding(
+            padding: EdgeInsets.all(16.0),
             child: Row(
               children: [
                 Text("アプリについて"),
@@ -76,25 +82,53 @@ class _SettingModalState extends State<SettingModal> {
           ),
           Column(
             children: [
-              Container(
-                color: colors.onPrimary,
-                width: double.infinity,
-                child: Padding(
-                  padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
-                  child: Text(
-                    "アプリを評価する",
-                    style: TextStyle(fontSize: 16),
-                  ),
+              GestureDetector(
+                onTap: () {},
+                child: Column(
+                  children: [
+                    Container(
+                      color: colors.onPrimary,
+                      width: double.infinity,
+                      child: const Padding(
+                        padding: EdgeInsets.fromLTRB(16, 16, 16, 8),
+                        child: Text(
+                          "アプリを評価する",
+                          style: TextStyle(fontSize: 16),
+                        ),
+                      ),
+                    ),
+                    Container(
+                      color: colors.onPrimary,
+                      width: double.infinity,
+                      child: Padding(
+                        padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+                        child: Text(
+                          "レビューしてもらえると開発者が小躍りします",
+                          style: TextStyle(color: colors.outline),
+                        ),
+                      ),
+                    ),
+                  ],
                 ),
               ),
-              Container(
-                color: colors.onPrimary,
-                width: double.infinity,
-                child: Padding(
-                  padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
-                  child: Text(
-                    "レビューしてもらえると開発者が小躍りします",
-                    style: TextStyle(color: colors.outline),
+              Divider(
+                height: 0,
+                thickness: 1,
+                indent: 20,
+                endIndent: 20,
+                color: colors.surfaceVariant,
+              ),
+              GestureDetector(
+                onTap: () {},
+                child: Container(
+                  color: colors.onPrimary,
+                  width: double.infinity,
+                  child: const Padding(
+                    padding: EdgeInsets.all(16.0),
+                    child: Text(
+                      "サービス利用規約",
+                      style: TextStyle(fontSize: 16),
+                    ),
                   ),
                 ),
               ),
@@ -105,53 +139,41 @@ class _SettingModalState extends State<SettingModal> {
                 endIndent: 20,
                 color: colors.surfaceVariant,
               ),
-              Container(
-                color: colors.onPrimary,
-                width: double.infinity,
-                child: Padding(
-                  padding: const EdgeInsets.all(16.0),
-                  child: Text(
-                    "サービス利用規約",
-                    style: TextStyle(fontSize: 16),
-                  ),
-                ),
-              ),
-              Divider(
-                height: 0,
-                thickness: 1,
-                indent: 20,
-                endIndent: 20,
-                color: colors.surfaceVariant,
-              ),
-              Container(
-                color: colors.onPrimary,
-                width: double.infinity,
-                child: Padding(
-                  padding: const EdgeInsets.all(16.0),
-                  child: Text(
-                    "プライバシーポリシー",
-                    style: TextStyle(fontSize: 16),
+              GestureDetector(
+                onTap: () {},
+                child: Container(
+                  color: colors.onPrimary,
+                  width: double.infinity,
+                  child: const Padding(
+                    padding: EdgeInsets.all(16.0),
+                    child: Text(
+                      "プライバシーポリシー",
+                      style: TextStyle(fontSize: 16),
+                    ),
                   ),
                 ),
               ),
             ],
           ),
-          Padding(
-            padding: const EdgeInsets.all(16.0),
+          const Padding(
+            padding: EdgeInsets.all(16.0),
             child: Row(
               children: [
                 Text("その他"),
               ],
             ),
           ),
-          Container(
-            color: colors.onPrimary,
-            width: double.infinity,
-            child: Padding(
-              padding: const EdgeInsets.all(16.0),
-              child: Text(
-                "退会する",
-                style: TextStyle(color: colors.error, fontSize: 16),
+          GestureDetector(
+            onTap: () {},
+            child: Container(
+              color: colors.onPrimary,
+              width: double.infinity,
+              child: Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: Text(
+                  "退会する",
+                  style: TextStyle(color: colors.error, fontSize: 16),
+                ),
               ),
             ),
           )

--- a/lib/presentation/setting_page.dart
+++ b/lib/presentation/setting_page.dart
@@ -114,8 +114,8 @@ class _SettingModalState extends State<SettingModal> {
               Divider(
                 height: 0,
                 thickness: 1,
-                indent: 20,
-                endIndent: 20,
+                indent: 16,
+                endIndent: 16,
                 color: colors.surfaceVariant,
               ),
               GestureDetector(
@@ -135,8 +135,8 @@ class _SettingModalState extends State<SettingModal> {
               Divider(
                 height: 0,
                 thickness: 1,
-                indent: 20,
-                endIndent: 20,
+                indent: 16,
+                endIndent: 16,
                 color: colors.surfaceVariant,
               ),
               GestureDetector(

--- a/lib/presentation/setting_page.dart
+++ b/lib/presentation/setting_page.dart
@@ -25,98 +25,46 @@ class _SettingModalState extends State<SettingModal> {
           icon: const Icon(Icons.close),
         ),
       ),
-      body: Column(
-        mainAxisAlignment: MainAxisAlignment.start,
+      body: ListView(
         children: [
-          const Padding(
-            padding: EdgeInsets.all(16.0),
-            child: Row(
-              children: [
-                Text("編集"),
-              ],
-            ),
-          ),
-          GestureDetector(
-            onTap: () {},
-            child: Container(
-              color: colors.onPrimary,
-              width: double.infinity,
-              child: const Padding(
-                padding: EdgeInsets.all(16.0),
-                child: Text(
-                  "症状ワークシート",
-                  style: TextStyle(fontSize: 16),
-                ),
-              ),
-            ),
-          ),
-          const Padding(
-            padding: EdgeInsets.all(16.0),
-            child: Row(
-              children: [
-                Text("サポート"),
-              ],
-            ),
-          ),
-          GestureDetector(
-            onTap: () {},
-            child: Container(
-              color: colors.onPrimary,
-              width: double.infinity,
-              child: const Padding(
-                padding: EdgeInsets.all(16.0),
-                child: Text(
-                  "お問い合わせ",
-                  style: TextStyle(fontSize: 16),
-                ),
-              ),
-            ),
-          ),
-          const Padding(
-            padding: EdgeInsets.all(16.0),
-            child: Row(
-              children: [
-                Text("アプリについて"),
-              ],
-            ),
-          ),
           Column(
+            mainAxisAlignment: MainAxisAlignment.start,
             children: [
-              GestureDetector(
-                onTap: () {},
-                child: Column(
+              const Padding(
+                padding: EdgeInsets.all(20.0),
+                child: Row(
                   children: [
-                    Container(
-                      color: colors.onPrimary,
-                      width: double.infinity,
-                      child: const Padding(
-                        padding: EdgeInsets.fromLTRB(16, 16, 16, 8),
-                        child: Text(
-                          "アプリを評価する",
-                          style: TextStyle(fontSize: 16),
-                        ),
-                      ),
-                    ),
-                    Container(
-                      color: colors.onPrimary,
-                      width: double.infinity,
-                      child: Padding(
-                        padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
-                        child: Text(
-                          "レビューしてもらえると開発者が小躍りします",
-                          style: TextStyle(color: colors.outline),
-                        ),
-                      ),
+                    Text(
+                      "編集",
+                      style: TextStyle(fontSize: 16),
                     ),
                   ],
                 ),
               ),
-              Divider(
-                height: 0,
-                thickness: 1,
-                indent: 16,
-                endIndent: 16,
-                color: colors.surfaceVariant,
+              GestureDetector(
+                onTap: () {},
+                child: Container(
+                  color: colors.onPrimary,
+                  width: double.infinity,
+                  child: const Padding(
+                    padding: EdgeInsets.all(20.0),
+                    child: Text(
+                      "症状ワークシート",
+                      style: TextStyle(fontSize: 18),
+                    ),
+                  ),
+                ),
+              ),
+              const Padding(
+                padding: EdgeInsets.all(16.0),
+                child: Row(
+                  children: [
+                    Text(
+                      "サポート",
+                      style: TextStyle(fontSize: 16),
+                    ),
+                  ],
+                ),
               ),
               GestureDetector(
                 onTap: () {},
@@ -124,59 +72,131 @@ class _SettingModalState extends State<SettingModal> {
                   color: colors.onPrimary,
                   width: double.infinity,
                   child: const Padding(
-                    padding: EdgeInsets.all(16.0),
+                    padding: EdgeInsets.all(20.0),
                     child: Text(
-                      "サービス利用規約",
-                      style: TextStyle(fontSize: 16),
+                      "お問い合わせ",
+                      style: TextStyle(fontSize: 18),
                     ),
                   ),
                 ),
               ),
-              Divider(
-                height: 0,
-                thickness: 1,
-                indent: 16,
-                endIndent: 16,
-                color: colors.surfaceVariant,
+              const Padding(
+                padding: EdgeInsets.all(20.0),
+                child: Row(
+                  children: [
+                    Text(
+                      "アプリについて",
+                      style: TextStyle(fontSize: 16),
+                    ),
+                  ],
+                ),
+              ),
+              Column(
+                children: [
+                  GestureDetector(
+                    onTap: () {},
+                    child: Column(
+                      children: [
+                        Container(
+                          color: colors.onPrimary,
+                          width: double.infinity,
+                          child: const Padding(
+                            padding: EdgeInsets.fromLTRB(20, 20, 20, 8),
+                            child: Text(
+                              "アプリを評価する",
+                              style: TextStyle(fontSize: 18),
+                            ),
+                          ),
+                        ),
+                        Container(
+                          color: colors.onPrimary,
+                          width: double.infinity,
+                          child: Padding(
+                            padding: const EdgeInsets.fromLTRB(20, 0, 20, 20),
+                            child: Text(
+                              "レビューしてもらえると開発者が小躍りします",
+                              style: TextStyle(
+                                  color: colors.outline, fontSize: 16),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  Divider(
+                    height: 0,
+                    thickness: 1,
+                    indent: 16,
+                    endIndent: 16,
+                    color: colors.surfaceVariant,
+                  ),
+                  GestureDetector(
+                    onTap: () {},
+                    child: Container(
+                      color: colors.onPrimary,
+                      width: double.infinity,
+                      child: const Padding(
+                        padding: EdgeInsets.all(20.0),
+                        child: Text(
+                          "サービス利用規約",
+                          style: TextStyle(fontSize: 18),
+                        ),
+                      ),
+                    ),
+                  ),
+                  Divider(
+                    height: 0,
+                    thickness: 1,
+                    indent: 16,
+                    endIndent: 16,
+                    color: colors.surfaceVariant,
+                  ),
+                  GestureDetector(
+                    onTap: () {},
+                    child: Container(
+                      color: colors.onPrimary,
+                      width: double.infinity,
+                      child: const Padding(
+                        padding: EdgeInsets.all(20.0),
+                        child: Text(
+                          "プライバシーポリシー",
+                          style: TextStyle(fontSize: 18),
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              const Padding(
+                padding: EdgeInsets.all(20.0),
+                child: Row(
+                  children: [
+                    Text(
+                      "その他",
+                      style: TextStyle(fontSize: 16),
+                    ),
+                  ],
+                ),
               ),
               GestureDetector(
                 onTap: () {},
                 child: Container(
                   color: colors.onPrimary,
                   width: double.infinity,
-                  child: const Padding(
-                    padding: EdgeInsets.all(16.0),
+                  child: Padding(
+                    padding: const EdgeInsets.all(20.0),
                     child: Text(
-                      "プライバシーポリシー",
-                      style: TextStyle(fontSize: 16),
+                      "退会する",
+                      style: TextStyle(color: colors.error, fontSize: 18),
                     ),
                   ),
                 ),
               ),
+              SizedBox(
+                height: 50,
+              )
             ],
           ),
-          const Padding(
-            padding: EdgeInsets.all(16.0),
-            child: Row(
-              children: [
-                Text("その他"),
-              ],
-            ),
-          ),
-          GestureDetector(
-            onTap: () {},
-            child: Container(
-              color: colors.onPrimary,
-              width: double.infinity,
-              child: Padding(
-                padding: const EdgeInsets.all(16.0),
-                child: Text(
-                  "退会する",
-                  style: TextStyle(color: colors.error, fontSize: 16),
-                ),
-              ),
-            ),
-          )
         ],
       ),
     );

--- a/lib/presentation/setting_page.dart
+++ b/lib/presentation/setting_page.dart
@@ -27,19 +27,104 @@ class _SettingModalState extends State<SettingModal> {
       ),
       body: ListView(
         children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 30, 16, 8),
+            child: Row(
+              children: [
+                Text(
+                  "編集",
+                  style: TextStyle(fontSize: 16, color: colors.outline),
+                ),
+              ],
+            ),
+          ),
+          GestureDetector(
+            onTap: () {},
+            child: Container(
+              color: colors.onPrimary,
+              width: double.infinity,
+              child: const Padding(
+                padding: EdgeInsets.fromLTRB(16, 20, 16, 20),
+                child: Text(
+                  "症状ワークシート",
+                  style: TextStyle(fontSize: 18),
+                ),
+              ),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 20, 20, 8),
+            child: Row(
+              children: [
+                Text(
+                  "サポート",
+                  style: TextStyle(fontSize: 16, color: colors.outline),
+                ),
+              ],
+            ),
+          ),
+          GestureDetector(
+            onTap: () {},
+            child: Container(
+              color: colors.onPrimary,
+              width: double.infinity,
+              child: const Padding(
+                padding: EdgeInsets.fromLTRB(16, 20, 16, 20),
+                child: Text(
+                  "お問い合わせ",
+                  style: TextStyle(fontSize: 18),
+                ),
+              ),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 20, 20, 8),
+            child: Row(
+              children: [
+                Text(
+                  "アプリについて",
+                  style: TextStyle(fontSize: 16, color: colors.outline),
+                ),
+              ],
+            ),
+          ),
           Column(
-            mainAxisAlignment: MainAxisAlignment.start,
             children: [
-              Padding(
-                padding: const EdgeInsets.fromLTRB(16, 30, 16, 8),
-                child: Row(
+              GestureDetector(
+                onTap: () {},
+                child: Column(
                   children: [
-                    Text(
-                      "編集",
-                      style: TextStyle(fontSize: 16, color: colors.outline),
+                    Container(
+                      color: colors.onPrimary,
+                      width: double.infinity,
+                      child: const Padding(
+                        padding: EdgeInsets.fromLTRB(16, 20, 16, 8),
+                        child: Text(
+                          "アプリを評価する",
+                          style: TextStyle(fontSize: 18),
+                        ),
+                      ),
+                    ),
+                    Container(
+                      color: colors.onPrimary,
+                      width: double.infinity,
+                      child: Padding(
+                        padding: const EdgeInsets.fromLTRB(16, 0, 16, 20),
+                        child: Text(
+                          "レビューしてもらえると開発者が小躍りします",
+                          style: TextStyle(color: colors.outline, fontSize: 16),
+                        ),
+                      ),
                     ),
                   ],
                 ),
+              ),
+              Divider(
+                height: 0,
+                thickness: 1,
+                indent: 16,
+                endIndent: 16,
+                color: colors.surfaceVariant,
               ),
               GestureDetector(
                 onTap: () {},
@@ -49,22 +134,18 @@ class _SettingModalState extends State<SettingModal> {
                   child: const Padding(
                     padding: EdgeInsets.fromLTRB(16, 20, 16, 20),
                     child: Text(
-                      "症状ワークシート",
+                      "サービス利用規約",
                       style: TextStyle(fontSize: 18),
                     ),
                   ),
                 ),
               ),
-              Padding(
-                padding: const EdgeInsets.fromLTRB(16, 20, 20, 8),
-                child: Row(
-                  children: [
-                    Text(
-                      "サポート",
-                      style: TextStyle(fontSize: 16, color: colors.outline),
-                    ),
-                  ],
-                ),
+              Divider(
+                height: 0,
+                thickness: 1,
+                indent: 16,
+                endIndent: 16,
+                color: colors.surfaceVariant,
               ),
               GestureDetector(
                 onTap: () {},
@@ -74,128 +155,41 @@ class _SettingModalState extends State<SettingModal> {
                   child: const Padding(
                     padding: EdgeInsets.fromLTRB(16, 20, 16, 20),
                     child: Text(
-                      "お問い合わせ",
+                      "プライバシーポリシー",
                       style: TextStyle(fontSize: 18),
                     ),
                   ),
                 ),
               ),
-              Padding(
-                padding: const EdgeInsets.fromLTRB(16, 20, 20, 8),
-                child: Row(
-                  children: [
-                    Text(
-                      "アプリについて",
-                      style: TextStyle(fontSize: 16, color: colors.outline),
-                    ),
-                  ],
-                ),
-              ),
-              Column(
-                children: [
-                  GestureDetector(
-                    onTap: () {},
-                    child: Column(
-                      children: [
-                        Container(
-                          color: colors.onPrimary,
-                          width: double.infinity,
-                          child: const Padding(
-                            padding: EdgeInsets.fromLTRB(16, 20, 16, 8),
-                            child: Text(
-                              "アプリを評価する",
-                              style: TextStyle(fontSize: 18),
-                            ),
-                          ),
-                        ),
-                        Container(
-                          color: colors.onPrimary,
-                          width: double.infinity,
-                          child: Padding(
-                            padding: const EdgeInsets.fromLTRB(16, 0, 16, 20),
-                            child: Text(
-                              "レビューしてもらえると開発者が小躍りします",
-                              style: TextStyle(
-                                  color: colors.outline, fontSize: 16),
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                  Divider(
-                    height: 0,
-                    thickness: 1,
-                    indent: 16,
-                    endIndent: 16,
-                    color: colors.surfaceVariant,
-                  ),
-                  GestureDetector(
-                    onTap: () {},
-                    child: Container(
-                      color: colors.onPrimary,
-                      width: double.infinity,
-                      child: const Padding(
-                        padding: EdgeInsets.fromLTRB(16, 20, 16, 20),
-                        child: Text(
-                          "サービス利用規約",
-                          style: TextStyle(fontSize: 18),
-                        ),
-                      ),
-                    ),
-                  ),
-                  Divider(
-                    height: 0,
-                    thickness: 1,
-                    indent: 16,
-                    endIndent: 16,
-                    color: colors.surfaceVariant,
-                  ),
-                  GestureDetector(
-                    onTap: () {},
-                    child: Container(
-                      color: colors.onPrimary,
-                      width: double.infinity,
-                      child: const Padding(
-                        padding: EdgeInsets.fromLTRB(16, 20, 16, 20),
-                        child: Text(
-                          "プライバシーポリシー",
-                          style: TextStyle(fontSize: 18),
-                        ),
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-              Padding(
-                padding: const EdgeInsets.fromLTRB(16, 20, 16, 8),
-                child: Row(
-                  children: [
-                    Text(
-                      "その他",
-                      style: TextStyle(fontSize: 16, color: colors.outline),
-                    ),
-                  ],
-                ),
-              ),
-              GestureDetector(
-                onTap: () {},
-                child: Container(
-                  color: colors.onPrimary,
-                  width: double.infinity,
-                  child: Padding(
-                    padding: const EdgeInsets.fromLTRB(16, 20, 16, 20),
-                    child: Text(
-                      "退会する",
-                      style: TextStyle(color: colors.error, fontSize: 18),
-                    ),
-                  ),
-                ),
-              ),
-              const SizedBox(
-                height: 50,
-              )
             ],
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 20, 16, 8),
+            child: Row(
+              children: [
+                Text(
+                  "その他",
+                  style: TextStyle(fontSize: 16, color: colors.outline),
+                ),
+              ],
+            ),
+          ),
+          GestureDetector(
+            onTap: () {},
+            child: Container(
+              color: colors.onPrimary,
+              width: double.infinity,
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(16, 20, 16, 20),
+                child: Text(
+                  "退会する",
+                  style: TextStyle(color: colors.error, fontSize: 18),
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(
+            height: 50,
           ),
         ],
       ),

--- a/lib/presentation/setting_page.dart
+++ b/lib/presentation/setting_page.dart
@@ -1,0 +1,162 @@
+import 'package:flutter/material.dart';
+
+class SettingModal extends StatefulWidget {
+  const SettingModal({super.key});
+
+  @override
+  State<SettingModal> createState() => _SettingModalState();
+}
+
+class _SettingModalState extends State<SettingModal> {
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+    return Scaffold(
+      backgroundColor: colors.surfaceVariant,
+      appBar: AppBar(
+        elevation: 0,
+        backgroundColor: Colors.transparent,
+        centerTitle: true,
+        title: Text("設定"),
+        leading: IconButton(
+          onPressed: () {
+            Navigator.of(context).pop();
+          },
+          icon: const Icon(Icons.close),
+        ),
+      ),
+      body: Column(
+        mainAxisAlignment: MainAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Row(
+              children: [
+                Text("編集"),
+              ],
+            ),
+          ),
+          Container(
+            color: colors.onPrimary,
+            width: double.infinity,
+            child: Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: Text(
+                "症状ワークシート",
+                style: TextStyle(fontSize: 16),
+              ),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Row(
+              children: [
+                Text("サポート"),
+              ],
+            ),
+          ),
+          Container(
+            color: colors.onPrimary,
+            width: double.infinity,
+            child: Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: Text(
+                "お問い合わせ",
+                style: TextStyle(fontSize: 16),
+              ),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Row(
+              children: [
+                Text("アプリについて"),
+              ],
+            ),
+          ),
+          Column(
+            children: [
+              Container(
+                color: colors.onPrimary,
+                width: double.infinity,
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+                  child: Text(
+                    "アプリを評価する",
+                    style: TextStyle(fontSize: 16),
+                  ),
+                ),
+              ),
+              Container(
+                color: colors.onPrimary,
+                width: double.infinity,
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+                  child: Text(
+                    "レビューしてもらえると開発者が小躍りします",
+                    style: TextStyle(color: colors.outline),
+                  ),
+                ),
+              ),
+              Divider(
+                height: 0,
+                thickness: 1,
+                indent: 20,
+                endIndent: 20,
+                color: colors.surfaceVariant,
+              ),
+              Container(
+                color: colors.onPrimary,
+                width: double.infinity,
+                child: Padding(
+                  padding: const EdgeInsets.all(16.0),
+                  child: Text(
+                    "サービス利用規約",
+                    style: TextStyle(fontSize: 16),
+                  ),
+                ),
+              ),
+              Divider(
+                height: 0,
+                thickness: 1,
+                indent: 20,
+                endIndent: 20,
+                color: colors.surfaceVariant,
+              ),
+              Container(
+                color: colors.onPrimary,
+                width: double.infinity,
+                child: Padding(
+                  padding: const EdgeInsets.all(16.0),
+                  child: Text(
+                    "プライバシーポリシー",
+                    style: TextStyle(fontSize: 16),
+                  ),
+                ),
+              ),
+            ],
+          ),
+          Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Row(
+              children: [
+                Text("その他"),
+              ],
+            ),
+          ),
+          Container(
+            color: colors.onPrimary,
+            width: double.infinity,
+            child: Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: Text(
+                "退会する",
+                style: TextStyle(color: colors.error, fontSize: 16),
+              ),
+            ),
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/setting_page.dart
+++ b/lib/presentation/setting_page.dart
@@ -1,13 +1,8 @@
 import 'package:flutter/material.dart';
 
-class SettingModal extends StatefulWidget {
-  const SettingModal({super.key});
+class SettingPage extends StatelessWidget {
+  const SettingPage({super.key});
 
-  @override
-  State<SettingModal> createState() => _SettingModalState();
-}
-
-class _SettingModalState extends State<SettingModal> {
   @override
   Widget build(BuildContext context) {
     final colors = Theme.of(context).colorScheme;
@@ -18,12 +13,6 @@ class _SettingModalState extends State<SettingModal> {
         backgroundColor: colors.onInverseSurface,
         centerTitle: true,
         title: const Text("設定"),
-        leading: IconButton(
-          onPressed: () {
-            Navigator.of(context).pop();
-          },
-          icon: const Icon(Icons.close),
-        ),
       ),
       body: ListView(
         children: [

--- a/lib/presentation/setting_page.dart
+++ b/lib/presentation/setting_page.dart
@@ -12,10 +12,10 @@ class _SettingModalState extends State<SettingModal> {
   Widget build(BuildContext context) {
     final colors = Theme.of(context).colorScheme;
     return Scaffold(
-      backgroundColor: colors.surfaceVariant,
+      backgroundColor: colors.onInverseSurface,
       appBar: AppBar(
         elevation: 0,
-        backgroundColor: Colors.transparent,
+        backgroundColor: colors.onInverseSurface,
         centerTitle: true,
         title: const Text("設定"),
         leading: IconButton(
@@ -30,13 +30,13 @@ class _SettingModalState extends State<SettingModal> {
           Column(
             mainAxisAlignment: MainAxisAlignment.start,
             children: [
-              const Padding(
-                padding: EdgeInsets.all(20.0),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 30, 16, 8),
                 child: Row(
                   children: [
                     Text(
                       "編集",
-                      style: TextStyle(fontSize: 16),
+                      style: TextStyle(fontSize: 16, color: colors.outline),
                     ),
                   ],
                 ),
@@ -47,7 +47,7 @@ class _SettingModalState extends State<SettingModal> {
                   color: colors.onPrimary,
                   width: double.infinity,
                   child: const Padding(
-                    padding: EdgeInsets.all(20.0),
+                    padding: EdgeInsets.fromLTRB(16, 20, 16, 20),
                     child: Text(
                       "症状ワークシート",
                       style: TextStyle(fontSize: 18),
@@ -55,13 +55,13 @@ class _SettingModalState extends State<SettingModal> {
                   ),
                 ),
               ),
-              const Padding(
-                padding: EdgeInsets.all(16.0),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 20, 20, 8),
                 child: Row(
                   children: [
                     Text(
                       "サポート",
-                      style: TextStyle(fontSize: 16),
+                      style: TextStyle(fontSize: 16, color: colors.outline),
                     ),
                   ],
                 ),
@@ -72,7 +72,7 @@ class _SettingModalState extends State<SettingModal> {
                   color: colors.onPrimary,
                   width: double.infinity,
                   child: const Padding(
-                    padding: EdgeInsets.all(20.0),
+                    padding: EdgeInsets.fromLTRB(16, 20, 16, 20),
                     child: Text(
                       "お問い合わせ",
                       style: TextStyle(fontSize: 18),
@@ -80,13 +80,13 @@ class _SettingModalState extends State<SettingModal> {
                   ),
                 ),
               ),
-              const Padding(
-                padding: EdgeInsets.all(20.0),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 20, 20, 8),
                 child: Row(
                   children: [
                     Text(
                       "アプリについて",
-                      style: TextStyle(fontSize: 16),
+                      style: TextStyle(fontSize: 16, color: colors.outline),
                     ),
                   ],
                 ),
@@ -101,7 +101,7 @@ class _SettingModalState extends State<SettingModal> {
                           color: colors.onPrimary,
                           width: double.infinity,
                           child: const Padding(
-                            padding: EdgeInsets.fromLTRB(20, 20, 20, 8),
+                            padding: EdgeInsets.fromLTRB(16, 20, 16, 8),
                             child: Text(
                               "アプリを評価する",
                               style: TextStyle(fontSize: 18),
@@ -112,7 +112,7 @@ class _SettingModalState extends State<SettingModal> {
                           color: colors.onPrimary,
                           width: double.infinity,
                           child: Padding(
-                            padding: const EdgeInsets.fromLTRB(20, 0, 20, 20),
+                            padding: const EdgeInsets.fromLTRB(16, 0, 16, 20),
                             child: Text(
                               "レビューしてもらえると開発者が小躍りします",
                               style: TextStyle(
@@ -136,7 +136,7 @@ class _SettingModalState extends State<SettingModal> {
                       color: colors.onPrimary,
                       width: double.infinity,
                       child: const Padding(
-                        padding: EdgeInsets.all(20.0),
+                        padding: EdgeInsets.fromLTRB(16, 20, 16, 20),
                         child: Text(
                           "サービス利用規約",
                           style: TextStyle(fontSize: 18),
@@ -157,7 +157,7 @@ class _SettingModalState extends State<SettingModal> {
                       color: colors.onPrimary,
                       width: double.infinity,
                       child: const Padding(
-                        padding: EdgeInsets.all(20.0),
+                        padding: EdgeInsets.fromLTRB(16, 20, 16, 20),
                         child: Text(
                           "プライバシーポリシー",
                           style: TextStyle(fontSize: 18),
@@ -167,13 +167,13 @@ class _SettingModalState extends State<SettingModal> {
                   ),
                 ],
               ),
-              const Padding(
-                padding: EdgeInsets.all(20.0),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 20, 16, 8),
                 child: Row(
                   children: [
                     Text(
                       "その他",
-                      style: TextStyle(fontSize: 16),
+                      style: TextStyle(fontSize: 16, color: colors.outline),
                     ),
                   ],
                 ),
@@ -184,7 +184,7 @@ class _SettingModalState extends State<SettingModal> {
                   color: colors.onPrimary,
                   width: double.infinity,
                   child: Padding(
-                    padding: const EdgeInsets.all(20.0),
+                    padding: const EdgeInsets.fromLTRB(16, 20, 16, 20),
                     child: Text(
                       "退会する",
                       style: TextStyle(color: colors.error, fontSize: 18),
@@ -192,7 +192,7 @@ class _SettingModalState extends State<SettingModal> {
                   ),
                 ),
               ),
-              SizedBox(
+              const SizedBox(
                 height: 50,
               )
             ],

--- a/lib/presentation/signin_page.dart
+++ b/lib/presentation/signin_page.dart
@@ -21,10 +21,8 @@ class SigninPage extends ConsumerWidget with ErrorHandlerMixin {
         decoration: BoxDecoration(
           gradient: LinearGradient(
             colors: [
-              colors.primary,
               colors.primaryContainer,
-              // AppColors.green
-              // AppColors.yellow,
+              colors.primary,
             ],
             begin: Alignment.topCenter,
             end: Alignment.bottomCenter,


### PR DESCRIPTION
## [Design Doc] 設定画面の実装(16)

close #16 

## 変更点
設定画面のUIの実装
（ついでにログイン画面の色味の反転）

### やったこと
設定画面のUIの実装
各所タップできるように実装

### やってないこと
設定画面のタップ後のロジックの実装

## スクリーンショット（該当する場合）

[15-issue.webm](https://github.com/Mood-Trend/mood-trend-flutter/assets/66543967/b01ada73-ad2e-4611-9238-50092a009fd7)

## レビューのポイント
コードの簡潔さ

必要であれば、下記項目を記載してください。

- 特にチェックしてほしいエリア

- 懸念点
GestureDetectorを使っているがもっといい方法はあるか
(ListViewを使ったことで限界スクロール時にUIが間延びする点) → 解決
スクロール時、AppBarの色が変わる点
モーダルのAppBarがiosだとカメラに重なる

![Simulator Screenshot - iPhone 14 Pro - 2023-11-23 at 17 33 00](https://github.com/Mood-Trend/mood-trend-flutter/assets/66543967/25b06b21-521f-4045-b75d-fcee5db23688)


- フィードバックや提案を求めるエリア

## 追加の注意点

必要であれば、レビュアーに知っておいてほしいその他の情報や注意点を記載してください。
