### PR TITLE
Feature/18 issue

### DIFF
--- a/lib/presentation/home_page.dart
+++ b/lib/presentation/home_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mood_trend_flutter/domain/mood_point.dart';
 import 'package:mood_trend_flutter/presentation/components/async_value_handler.dart';
 import 'package:mood_trend_flutter/presentation/components/loading.dart';
+import 'package:mood_trend_flutter/presentation/table_page.dart';
 import 'package:mood_trend_flutter/utils/page_navigator.dart';
 import 'package:syncfusion_flutter_charts/charts.dart';
 
@@ -208,7 +209,16 @@ class _MyWidgetState extends ConsumerState<InputModal> with ErrorHandlerMixin {
               Padding(
                 padding: const EdgeInsets.fromLTRB(18, 56, 18, 0),
                 child: IconButton(
-                  onPressed: () {},
+                  onPressed: () {
+                    showModalBottomSheet(
+                      backgroundColor: colors.background,
+                      isScrollControlled: true,
+                      context: context,
+                      builder: (context) {
+                        return const TableModal();
+                      },
+                    );
+                  },
                   icon: Icon(
                     Icons.align_horizontal_left,
                     color: colors.primary,

--- a/lib/presentation/home_page.dart
+++ b/lib/presentation/home_page.dart
@@ -109,6 +109,7 @@ class _MyWidgetState extends ConsumerState<InputModal> with ErrorHandlerMixin {
   double _moodValue = 1.0;
   @override
   Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
     return SizedBox(
       height: 410,
       child: Center(
@@ -204,7 +205,16 @@ class _MyWidgetState extends ConsumerState<InputModal> with ErrorHandlerMixin {
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              const SizedBox(width: 80),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(18, 56, 18, 0),
+                child: IconButton(
+                  onPressed: () {},
+                  icon: Icon(
+                    Icons.align_horizontal_left,
+                    color: colors.primary,
+                  ),
+                ),
+              ),
               Row(
                 children: [
                   const Text(

--- a/lib/presentation/table_page.dart
+++ b/lib/presentation/table_page.dart
@@ -36,6 +36,9 @@ class _TableModalState extends State<TableModal> {
       body: Center(
         child: ListView(
           children: const [
+            SizedBox(
+              height: 16,
+            ),
             TableCard(
               moodValue: "+5",
               actionText: "アイデアが湧いてきて止まらない。実現に向けて実際に向けて動く。",

--- a/lib/presentation/table_page.dart
+++ b/lib/presentation/table_page.dart
@@ -1,0 +1,135 @@
+import 'package:flutter/material.dart';
+
+class TableModal extends StatefulWidget {
+  const TableModal({super.key});
+
+  @override
+  State<TableModal> createState() => _TableModalState();
+}
+
+class _TableModalState extends State<TableModal> {
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+    return Scaffold(
+      backgroundColor: colors.surfaceVariant,
+      appBar: AppBar(
+        elevation: 0,
+        backgroundColor: Colors.transparent,
+        centerTitle: true,
+        title: Text("症状ワークシート"),
+        leading: IconButton(
+          onPressed: () {
+            Navigator.of(context).pop();
+          },
+          icon: const Icon(Icons.close),
+        ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        backgroundColor: colors.primary,
+        onPressed: () {},
+        child: Icon(
+          Icons.mode_edit,
+          color: colors.onPrimary,
+        ),
+      ),
+      body: Center(
+        child: ListView(
+          children: const [
+            TableCard(
+              moodValue: "+5",
+              actionText: "アイデアが湧いてきて止まらない。実現に向けて実際に向けて動く。",
+            ),
+            TableCard(
+              moodValue: "+4",
+              actionText: "",
+            ),
+            TableCard(
+              moodValue: "+3",
+              actionText: "何かしたくてたまらない",
+            ),
+            TableCard(
+              moodValue: "+2",
+              actionText: "",
+            ),
+            TableCard(
+              moodValue: "+1",
+              actionText: "朝目覚めて前向きな気持ちがする",
+            ),
+            SizedBox(
+              height: 30,
+            ),
+            TableCard(
+              moodValue: "-1",
+              actionText: "朝目覚めて後ろ向きな気持ちがする",
+            ),
+            TableCard(
+              moodValue: "-2",
+              actionText: "",
+            ),
+            TableCard(
+              moodValue: "-3",
+              actionText: "色々なことやめたくなる。何をする気力も自信もない。",
+            ),
+            TableCard(
+              moodValue: "-4",
+              actionText: "",
+            ),
+            TableCard(
+              moodValue: "-5",
+              actionText: "自分に価値はなく、迷惑な存在と思う。死を考える。",
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class TableCard extends StatelessWidget {
+  const TableCard({
+    super.key,
+    required this.moodValue,
+    required this.actionText,
+  });
+
+  final String moodValue;
+  final String actionText;
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+    return Card(
+      margin: EdgeInsets.all(10),
+      color: colors.onPrimary,
+      child: Row(
+        children: [
+          Container(
+            height: 80,
+            width: 50,
+            decoration: BoxDecoration(
+              color: colors.inverseSurface,
+              borderRadius: const BorderRadius.only(
+                topLeft: Radius.circular(10.0),
+                bottomLeft: Radius.circular(10.0),
+              ),
+            ),
+            child: Center(
+                child: Text(
+              moodValue,
+              style: TextStyle(color: colors.onPrimary, fontSize: 21),
+            )),
+          ),
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: Text(
+                actionText,
+                textAlign: TextAlign.left,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/table_page.dart
+++ b/lib/presentation/table_page.dart
@@ -17,7 +17,7 @@ class _TableModalState extends State<TableModal> {
         elevation: 0,
         backgroundColor: Colors.transparent,
         centerTitle: true,
-        title: Text("症状ワークシート"),
+        title: const Text("症状ワークシート"),
         leading: IconButton(
           onPressed: () {
             Navigator.of(context).pop();
@@ -102,7 +102,7 @@ class TableCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final colors = Theme.of(context).colorScheme;
     return Card(
-      margin: EdgeInsets.all(10),
+      margin: const EdgeInsets.all(10),
       color: colors.onPrimary,
       child: Row(
         children: [
@@ -110,7 +110,7 @@ class TableCard extends StatelessWidget {
             height: 80,
             width: 50,
             decoration: BoxDecoration(
-              color: colors.inverseSurface,
+              color: colors.secondaryContainer,
               borderRadius: const BorderRadius.only(
                 topLeft: Radius.circular(10.0),
                 bottomLeft: Radius.circular(10.0),
@@ -119,15 +119,24 @@ class TableCard extends StatelessWidget {
             child: Center(
                 child: Text(
               moodValue,
-              style: TextStyle(color: colors.onPrimary, fontSize: 21),
+              style: TextStyle(color: colors.outline, fontSize: 22),
             )),
           ),
           Expanded(
-            child: Padding(
-              padding: const EdgeInsets.all(8.0),
-              child: Text(
-                actionText,
-                textAlign: TextAlign.left,
+            child: SizedBox(
+              // これがないと文字数が多い時にUIが崩れる
+              height: 80,
+              child: Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: Center(
+                  child: Text(
+                    actionText,
+                    style: TextStyle(
+                      fontSize: 16,
+                      color: colors.inverseSurface,
+                    ),
+                  ),
+                ),
               ),
             ),
           ),


### PR DESCRIPTION
## [Design Doc] 行動表（症状ワークシート）画面の実装(18)

close #18

## 変更点
症状ワークシートのUIの実装

### やったこと
入力モーダルから症状ワークシートに飛ぶアイコンボタンの実装
症状ワークシートのUIの実装

### やってないこと
症状ワークシートの編集画面の実装

## スクリーンショット（該当する場合）
![simulator_screenshot_D7EB492C-68EA-4D11-BCBE-534E93526401](https://github.com/Mood-Trend/mood-trend-flutter/assets/66543967/f5e72cfe-dae7-4da7-9a8a-e2d847177ef7)


## レビューのポイント
症状ワークシート編集画面と同じWigetを使い回すための書き方がわからなかった
iosの場合AppBarがカメラに重なる
文字の左寄せの必要があるか

- 特にチェックしてほしいエリア
- 懸念点
- フィードバックや提案を求めるエリア

## 追加の注意点

必要であれば、レビュアーに知っておいてほしいその他の情報や注意点を記載してください。
