### PR TITLE
設定画面のタップ時の挙動を仮追加

### DIFF
--- a/lib/infrastructure/firebase/auth_repository.dart
+++ b/lib/infrastructure/firebase/auth_repository.dart
@@ -54,6 +54,12 @@ class FirebaseAuthRepository {
     // Firebase Auth からログアウトする
     await auth.signOut();
   }
+
+  /// 認証ユーザーを削除する
+  Future<void> delete() async {
+    // Firebase Auth から現在のユーザーを削除する
+    await auth.currentUser?.delete();
+  }
 }
 
 /// [FirebaseAuthException] を [AuthException] に変換する拡張メソッド

--- a/lib/presentation/components/snackbars.dart
+++ b/lib/presentation/components/snackbars.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-final scaffoldMessengerKeyProvider =
-    Provider((_) => GlobalKey<ScaffoldMessengerState>());
+final scaffoldMessengerKeyProvider = Provider(
+  (_) => GlobalKey<ScaffoldMessengerState>(),
+);
 
 /// 処理成功用の [SnackBar]
 class SuccessSnackBar extends SnackBar {

--- a/lib/presentation/mixin/error_handler_mixin.dart
+++ b/lib/presentation/mixin/error_handler_mixin.dart
@@ -13,17 +13,19 @@ mixin ErrorHandlerMixin {
     required Future<void> Function() action,
     required String successMessage,
   }) async {
-    final scaffoldMessenger = ScaffoldMessenger.of(context);
+    final isShowSnackBar = successMessage.isNotEmpty;
     ref.read(overlayLoadingProvider.notifier).update((_) => true);
     try {
       await action();
+      if (!isShowSnackBar) return;
       SuccessSnackBar.show(
-        scaffoldMessenger,
+        ScaffoldMessenger.of(context),
         message: successMessage,
       );
     } on AppException catch (e) {
+      if (!isShowSnackBar) return;
       FailureSnackBar.show(
-        scaffoldMessenger,
+        ScaffoldMessenger.of(context),
         message: e.toString(),
       );
     } finally {

--- a/lib/presentation/mixin/error_handler_mixin.dart
+++ b/lib/presentation/mixin/error_handler_mixin.dart
@@ -13,21 +13,16 @@ mixin ErrorHandlerMixin {
     required Future<void> Function() action,
     required String successMessage,
   }) async {
-    final isShowSnackBar = successMessage.isNotEmpty;
+    final scaffoldMessenger =
+        ref.read(scaffoldMessengerKeyProvider).currentState;
     ref.read(overlayLoadingProvider.notifier).update((_) => true);
     try {
       await action();
-      if (!isShowSnackBar) return;
-      SuccessSnackBar.show(
-        ScaffoldMessenger.of(context),
-        message: successMessage,
-      );
+      if (scaffoldMessenger == null) return;
+      SuccessSnackBar.show(scaffoldMessenger, message: successMessage);
     } on AppException catch (e) {
-      if (!isShowSnackBar) return;
-      FailureSnackBar.show(
-        ScaffoldMessenger.of(context),
-        message: e.toString(),
-      );
+      if (scaffoldMessenger == null) return;
+      FailureSnackBar.show(scaffoldMessenger, message: e.toString());
     } finally {
       ref.read(overlayLoadingProvider.notifier).update((_) => false);
     }

--- a/lib/presentation/setting_page.dart
+++ b/lib/presentation/setting_page.dart
@@ -1,11 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mood_trend_flutter/infrastructure/firebase/auth_repository.dart';
+import 'package:mood_trend_flutter/presentation/mixin/error_handler_mixin.dart';
 import 'package:mood_trend_flutter/presentation/table_page.dart';
 import 'package:mood_trend_flutter/utils/page_navigator.dart';
 
 import '../utils/url_launcher_service.dart';
 
-class SettingPage extends ConsumerWidget {
+class SettingPage extends ConsumerWidget with ErrorHandlerMixin {
   const SettingPage({super.key});
 
   @override
@@ -192,7 +194,13 @@ class SettingPage extends ConsumerWidget {
                       ),
                       TextButton(
                         child: const Text("退会する"),
-                        onPressed: () => Navigator.pop(context),
+                        onPressed: () {
+                          execute(context, ref, action: () async {
+                            await ref
+                                .read(firebaseAuthRepositoryProvider)
+                                .delete();
+                          }, successMessage: '');
+                        },
                       ),
                     ],
                   );

--- a/lib/presentation/setting_page.dart
+++ b/lib/presentation/setting_page.dart
@@ -199,7 +199,7 @@ class SettingPage extends ConsumerWidget with ErrorHandlerMixin {
                             await ref
                                 .read(firebaseAuthRepositoryProvider)
                                 .delete();
-                          }, successMessage: '');
+                          }, successMessage: 'ご利用いただきありがとうございました');
                         },
                       ),
                     ],

--- a/lib/presentation/setting_page.dart
+++ b/lib/presentation/setting_page.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mood_trend_flutter/utils/url_launcher_service.dart';
 
-class SettingPage extends StatelessWidget {
+class SettingPage extends ConsumerWidget {
   const SettingPage({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final colors = Theme.of(context).colorScheme;
     return Scaffold(
       backgroundColor: colors.onInverseSurface,
@@ -53,7 +55,9 @@ class SettingPage extends StatelessWidget {
             ),
           ),
           GestureDetector(
-            onTap: () {},
+            onTap: () async {
+              await ref.read(urlLauncherServiceProvider).launch('');
+            },
             child: Container(
               color: colors.onPrimary,
               width: double.infinity,
@@ -80,7 +84,9 @@ class SettingPage extends StatelessWidget {
           Column(
             children: [
               GestureDetector(
-                onTap: () {},
+                onTap: () async {
+                  await ref.read(urlLauncherServiceProvider).launch('');
+                },
                 child: Column(
                   children: [
                     Container(
@@ -116,7 +122,9 @@ class SettingPage extends StatelessWidget {
                 color: colors.surfaceVariant,
               ),
               GestureDetector(
-                onTap: () {},
+                onTap: () async {
+                  await ref.read(urlLauncherServiceProvider).launch('');
+                },
                 child: Container(
                   color: colors.onPrimary,
                   width: double.infinity,
@@ -137,7 +145,9 @@ class SettingPage extends StatelessWidget {
                 color: colors.surfaceVariant,
               ),
               GestureDetector(
-                onTap: () {},
+                onTap: () async {
+                  await ref.read(urlLauncherServiceProvider).launch('');
+                },
                 child: Container(
                   color: colors.onPrimary,
                   width: double.infinity,
@@ -164,7 +174,27 @@ class SettingPage extends StatelessWidget {
             ),
           ),
           GestureDetector(
-            onTap: () {},
+            onTap: () {
+              showDialog(
+                context: context,
+                builder: (context) {
+                  return AlertDialog(
+                    title: const Text("退会しますか？"),
+                    content: const Text("データは全て削除され復元できません"),
+                    actions: [
+                      TextButton(
+                        child: const Text("キャンセル"),
+                        onPressed: () => Navigator.pop(context),
+                      ),
+                      TextButton(
+                        child: const Text("退会する"),
+                        onPressed: () => Navigator.pop(context),
+                      ),
+                    ],
+                  );
+                },
+              );
+            },
             child: Container(
               color: colors.onPrimary,
               width: double.infinity,


### PR DESCRIPTION
## 関連する Design Doc (Issue 番号)

close #issue-no

※ 他に関連する Issue や他のプルリクエスト があればそちらの番号も記載してください。

## 変更点
設定ページの各場所をタップした時の挙動を仮実装

### やったこと
URLを入れたらサイトに飛ぶところまでの実装
退会ダイアログを出す実装

### やってないこと
実際に退会する処理の実装
URLの準備

## スクリーンショット（該当する場合）

https://github.com/Mood-Trend/mood-trend-flutter/assets/66543967/758c499c-5d58-46b4-ae91-8771138bfe5c




## レビューのポイント

必要であれば、下記項目を記載してください。

- 特にチェックしてほしいエリア
- 懸念点
- フィードバックや提案を求めるエリア

## 追加の注意点

必要であれば、レビュアーに知っておいてほしいその他の情報や注意点を記載してください。
