### PR TITLE
fix: iOSビルドに必要なproject.pbxprojを.gitignoreから除外

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,6 @@ app.*.map.json
 
 # iOS ビルド
 /ios/Podfile.lock
-/ios/Runner.xcodeproj/project.pbxproj
 
 # FVM
 .fvm/


### PR DESCRIPTION
## 関連する Design Doc / Issue 番号

- なし


---

## 変更点

### やったこと

- `.gitignore` から `ios/Runner.xcodeproj/project.pbxproj` を除外
- Flutter iOS ビルドが失敗する問題への対処

### やってないこと

- 他の `.gitignore` の調整
- `project.pbxproj` の内容変更や修正は行っていない

---

## スクリーンショット（該当する場合）

- UI の変更はなし

---

## レビューのポイント

- `.gitignore` の該当行の削除による影響の有無
- チーム開発環境における `project.pbxproj` の追跡の是非

---

## 追加の注意点

- `.gitignore` に含めるとビルドが失敗するため、除外する方向で運用統一をお願いします
