### PR TITLE
chore: リントルール対応と依存アップデート（Flutter 3.16+対応）

### DIFF
--- a/lib/domain/app_confs.dart
+++ b/lib/domain/app_confs.dart
@@ -4,7 +4,7 @@ part 'app_confs.freezed.dart';
 
 /// AppConfs コレクションのドキュメント群
 @freezed
-class AppConfs with _$AppConfs {
+abstract class AppConfs with _$AppConfs {
   const factory AppConfs({
     /// レビューメニューを表示するかどうか
     required bool isShowReviewMenu,

--- a/lib/domain/app_confs.freezed.dart
+++ b/lib/domain/app_confs.freezed.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
@@ -9,90 +10,68 @@ part of 'app_confs.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
 
 /// @nodoc
 mixin _$AppConfs {
   /// レビューメニューを表示するかどうか
-  bool get isShowReviewMenu => throw _privateConstructorUsedError;
+  bool get isShowReviewMenu;
 
   /// iOS のレビュー URL
-  String get reviewUrlIos => throw _privateConstructorUsedError;
+  String get reviewUrlIos;
 
   /// Android のレビュー URL
-  String get reviewUrlAndroid => throw _privateConstructorUsedError;
+  String get reviewUrlAndroid;
 
-  @JsonKey(ignore: true)
-  $AppConfsCopyWith<AppConfs> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $AppConfsCopyWith<$Res> {
-  factory $AppConfsCopyWith(AppConfs value, $Res Function(AppConfs) then) =
-      _$AppConfsCopyWithImpl<$Res, AppConfs>;
-  @useResult
-  $Res call(
-      {bool isShowReviewMenu, String reviewUrlIos, String reviewUrlAndroid});
-}
-
-/// @nodoc
-class _$AppConfsCopyWithImpl<$Res, $Val extends AppConfs>
-    implements $AppConfsCopyWith<$Res> {
-  _$AppConfsCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
+  /// Create a copy of AppConfs
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @pragma('vm:prefer-inline')
+  $AppConfsCopyWith<AppConfs> get copyWith =>
+      _$AppConfsCopyWithImpl<AppConfs>(this as AppConfs, _$identity);
+
   @override
-  $Res call({
-    Object? isShowReviewMenu = null,
-    Object? reviewUrlIos = null,
-    Object? reviewUrlAndroid = null,
-  }) {
-    return _then(_value.copyWith(
-      isShowReviewMenu: null == isShowReviewMenu
-          ? _value.isShowReviewMenu
-          : isShowReviewMenu // ignore: cast_nullable_to_non_nullable
-              as bool,
-      reviewUrlIos: null == reviewUrlIos
-          ? _value.reviewUrlIos
-          : reviewUrlIos // ignore: cast_nullable_to_non_nullable
-              as String,
-      reviewUrlAndroid: null == reviewUrlAndroid
-          ? _value.reviewUrlAndroid
-          : reviewUrlAndroid // ignore: cast_nullable_to_non_nullable
-              as String,
-    ) as $Val);
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is AppConfs &&
+            (identical(other.isShowReviewMenu, isShowReviewMenu) ||
+                other.isShowReviewMenu == isShowReviewMenu) &&
+            (identical(other.reviewUrlIos, reviewUrlIos) ||
+                other.reviewUrlIos == reviewUrlIos) &&
+            (identical(other.reviewUrlAndroid, reviewUrlAndroid) ||
+                other.reviewUrlAndroid == reviewUrlAndroid));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, isShowReviewMenu, reviewUrlIos, reviewUrlAndroid);
+
+  @override
+  String toString() {
+    return 'AppConfs(isShowReviewMenu: $isShowReviewMenu, reviewUrlIos: $reviewUrlIos, reviewUrlAndroid: $reviewUrlAndroid)';
   }
 }
 
 /// @nodoc
-abstract class _$$AppConfsImplCopyWith<$Res>
-    implements $AppConfsCopyWith<$Res> {
-  factory _$$AppConfsImplCopyWith(
-          _$AppConfsImpl value, $Res Function(_$AppConfsImpl) then) =
-      __$$AppConfsImplCopyWithImpl<$Res>;
-  @override
+abstract mixin class $AppConfsCopyWith<$Res> {
+  factory $AppConfsCopyWith(AppConfs value, $Res Function(AppConfs) _then) =
+      _$AppConfsCopyWithImpl;
   @useResult
   $Res call(
       {bool isShowReviewMenu, String reviewUrlIos, String reviewUrlAndroid});
 }
 
 /// @nodoc
-class __$$AppConfsImplCopyWithImpl<$Res>
-    extends _$AppConfsCopyWithImpl<$Res, _$AppConfsImpl>
-    implements _$$AppConfsImplCopyWith<$Res> {
-  __$$AppConfsImplCopyWithImpl(
-      _$AppConfsImpl _value, $Res Function(_$AppConfsImpl) _then)
-      : super(_value, _then);
+class _$AppConfsCopyWithImpl<$Res> implements $AppConfsCopyWith<$Res> {
+  _$AppConfsCopyWithImpl(this._self, this._then);
 
+  final AppConfs _self;
+  final $Res Function(AppConfs) _then;
+
+  /// Create a copy of AppConfs
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -100,17 +79,17 @@ class __$$AppConfsImplCopyWithImpl<$Res>
     Object? reviewUrlIos = null,
     Object? reviewUrlAndroid = null,
   }) {
-    return _then(_$AppConfsImpl(
+    return _then(_self.copyWith(
       isShowReviewMenu: null == isShowReviewMenu
-          ? _value.isShowReviewMenu
+          ? _self.isShowReviewMenu
           : isShowReviewMenu // ignore: cast_nullable_to_non_nullable
               as bool,
       reviewUrlIos: null == reviewUrlIos
-          ? _value.reviewUrlIos
+          ? _self.reviewUrlIos
           : reviewUrlIos // ignore: cast_nullable_to_non_nullable
               as String,
       reviewUrlAndroid: null == reviewUrlAndroid
-          ? _value.reviewUrlAndroid
+          ? _self.reviewUrlAndroid
           : reviewUrlAndroid // ignore: cast_nullable_to_non_nullable
               as String,
     ));
@@ -119,8 +98,8 @@ class __$$AppConfsImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$AppConfsImpl implements _AppConfs {
-  const _$AppConfsImpl(
+class _AppConfs implements AppConfs {
+  const _AppConfs(
       {required this.isShowReviewMenu,
       required this.reviewUrlIos,
       required this.reviewUrlAndroid});
@@ -137,16 +116,19 @@ class _$AppConfsImpl implements _AppConfs {
   @override
   final String reviewUrlAndroid;
 
+  /// Create a copy of AppConfs
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  String toString() {
-    return 'AppConfs(isShowReviewMenu: $isShowReviewMenu, reviewUrlIos: $reviewUrlIos, reviewUrlAndroid: $reviewUrlAndroid)';
-  }
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$AppConfsCopyWith<_AppConfs> get copyWith =>
+      __$AppConfsCopyWithImpl<_AppConfs>(this, _$identity);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$AppConfsImpl &&
+            other is _AppConfs &&
             (identical(other.isShowReviewMenu, isShowReviewMenu) ||
                 other.isShowReviewMenu == isShowReviewMenu) &&
             (identical(other.reviewUrlIos, reviewUrlIos) ||
@@ -159,33 +141,54 @@ class _$AppConfsImpl implements _AppConfs {
   int get hashCode => Object.hash(
       runtimeType, isShowReviewMenu, reviewUrlIos, reviewUrlAndroid);
 
-  @JsonKey(ignore: true)
+  @override
+  String toString() {
+    return 'AppConfs(isShowReviewMenu: $isShowReviewMenu, reviewUrlIos: $reviewUrlIos, reviewUrlAndroid: $reviewUrlAndroid)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$AppConfsCopyWith<$Res>
+    implements $AppConfsCopyWith<$Res> {
+  factory _$AppConfsCopyWith(_AppConfs value, $Res Function(_AppConfs) _then) =
+      __$AppConfsCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {bool isShowReviewMenu, String reviewUrlIos, String reviewUrlAndroid});
+}
+
+/// @nodoc
+class __$AppConfsCopyWithImpl<$Res> implements _$AppConfsCopyWith<$Res> {
+  __$AppConfsCopyWithImpl(this._self, this._then);
+
+  final _AppConfs _self;
+  final $Res Function(_AppConfs) _then;
+
+  /// Create a copy of AppConfs
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
-  _$$AppConfsImplCopyWith<_$AppConfsImpl> get copyWith =>
-      __$$AppConfsImplCopyWithImpl<_$AppConfsImpl>(this, _$identity);
+  $Res call({
+    Object? isShowReviewMenu = null,
+    Object? reviewUrlIos = null,
+    Object? reviewUrlAndroid = null,
+  }) {
+    return _then(_AppConfs(
+      isShowReviewMenu: null == isShowReviewMenu
+          ? _self.isShowReviewMenu
+          : isShowReviewMenu // ignore: cast_nullable_to_non_nullable
+              as bool,
+      reviewUrlIos: null == reviewUrlIos
+          ? _self.reviewUrlIos
+          : reviewUrlIos // ignore: cast_nullable_to_non_nullable
+              as String,
+      reviewUrlAndroid: null == reviewUrlAndroid
+          ? _self.reviewUrlAndroid
+          : reviewUrlAndroid // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
 }
 
-abstract class _AppConfs implements AppConfs {
-  const factory _AppConfs(
-      {required final bool isShowReviewMenu,
-      required final String reviewUrlIos,
-      required final String reviewUrlAndroid}) = _$AppConfsImpl;
-
-  @override
-
-  /// レビューメニューを表示するかどうか
-  bool get isShowReviewMenu;
-  @override
-
-  /// iOS のレビュー URL
-  String get reviewUrlIos;
-  @override
-
-  /// Android のレビュー URL
-  String get reviewUrlAndroid;
-  @override
-  @JsonKey(ignore: true)
-  _$$AppConfsImplCopyWith<_$AppConfsImpl> get copyWith =>
-      throw _privateConstructorUsedError;
-}
+// dart format on

--- a/lib/domain/app_info.dart
+++ b/lib/domain/app_info.dart
@@ -10,7 +10,7 @@ final appInfoProvider = Provider<AppInfo>(
 
 /// アプリ情報
 @freezed
-class AppInfo with _$AppInfo {
+abstract class AppInfo with _$AppInfo {
   const factory AppInfo({
     /// アプリ名
     required String appName,

--- a/lib/domain/app_info.freezed.dart
+++ b/lib/domain/app_info.freezed.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
@@ -9,131 +10,91 @@ part of 'app_info.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
 
 /// @nodoc
 mixin _$AppInfo {
   /// アプリ名
-  String get appName => throw _privateConstructorUsedError;
+  String get appName;
 
   /// パッケージ名
-  String get packageName => throw _privateConstructorUsedError;
+  String get packageName;
 
   /// バージョン
-  String get version => throw _privateConstructorUsedError;
+  String get version;
 
   /// ビルド番号
-  String get buildNumber => throw _privateConstructorUsedError;
+  String get buildNumber;
 
   /// CopyRight
-  String get copyRight => throw _privateConstructorUsedError;
+  String get copyRight;
 
   /// アイコン画像へのパス
-  String get iconImagePath => throw _privateConstructorUsedError;
+  String get iconImagePath;
 
   /// プライバシーポリシーのURL
-  Uri get privacyPolicyUrl => throw _privateConstructorUsedError;
+  Uri get privacyPolicyUrl;
 
   /// 利用規約のURL
-  Uri get termsOfServiceUrl => throw _privateConstructorUsedError;
+  Uri get termsOfServiceUrl;
 
   /// コンタクトのURL
-  Uri get contactUrl => throw _privateConstructorUsedError;
+  Uri get contactUrl;
 
-  @JsonKey(ignore: true)
-  $AppInfoCopyWith<AppInfo> get copyWith => throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $AppInfoCopyWith<$Res> {
-  factory $AppInfoCopyWith(AppInfo value, $Res Function(AppInfo) then) =
-      _$AppInfoCopyWithImpl<$Res, AppInfo>;
-  @useResult
-  $Res call(
-      {String appName,
-      String packageName,
-      String version,
-      String buildNumber,
-      String copyRight,
-      String iconImagePath,
-      Uri privacyPolicyUrl,
-      Uri termsOfServiceUrl,
-      Uri contactUrl});
-}
-
-/// @nodoc
-class _$AppInfoCopyWithImpl<$Res, $Val extends AppInfo>
-    implements $AppInfoCopyWith<$Res> {
-  _$AppInfoCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
+  /// Create a copy of AppInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @pragma('vm:prefer-inline')
+  $AppInfoCopyWith<AppInfo> get copyWith =>
+      _$AppInfoCopyWithImpl<AppInfo>(this as AppInfo, _$identity);
+
   @override
-  $Res call({
-    Object? appName = null,
-    Object? packageName = null,
-    Object? version = null,
-    Object? buildNumber = null,
-    Object? copyRight = null,
-    Object? iconImagePath = null,
-    Object? privacyPolicyUrl = null,
-    Object? termsOfServiceUrl = null,
-    Object? contactUrl = null,
-  }) {
-    return _then(_value.copyWith(
-      appName: null == appName
-          ? _value.appName
-          : appName // ignore: cast_nullable_to_non_nullable
-              as String,
-      packageName: null == packageName
-          ? _value.packageName
-          : packageName // ignore: cast_nullable_to_non_nullable
-              as String,
-      version: null == version
-          ? _value.version
-          : version // ignore: cast_nullable_to_non_nullable
-              as String,
-      buildNumber: null == buildNumber
-          ? _value.buildNumber
-          : buildNumber // ignore: cast_nullable_to_non_nullable
-              as String,
-      copyRight: null == copyRight
-          ? _value.copyRight
-          : copyRight // ignore: cast_nullable_to_non_nullable
-              as String,
-      iconImagePath: null == iconImagePath
-          ? _value.iconImagePath
-          : iconImagePath // ignore: cast_nullable_to_non_nullable
-              as String,
-      privacyPolicyUrl: null == privacyPolicyUrl
-          ? _value.privacyPolicyUrl
-          : privacyPolicyUrl // ignore: cast_nullable_to_non_nullable
-              as Uri,
-      termsOfServiceUrl: null == termsOfServiceUrl
-          ? _value.termsOfServiceUrl
-          : termsOfServiceUrl // ignore: cast_nullable_to_non_nullable
-              as Uri,
-      contactUrl: null == contactUrl
-          ? _value.contactUrl
-          : contactUrl // ignore: cast_nullable_to_non_nullable
-              as Uri,
-    ) as $Val);
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is AppInfo &&
+            (identical(other.appName, appName) || other.appName == appName) &&
+            (identical(other.packageName, packageName) ||
+                other.packageName == packageName) &&
+            (identical(other.version, version) || other.version == version) &&
+            (identical(other.buildNumber, buildNumber) ||
+                other.buildNumber == buildNumber) &&
+            (identical(other.copyRight, copyRight) ||
+                other.copyRight == copyRight) &&
+            (identical(other.iconImagePath, iconImagePath) ||
+                other.iconImagePath == iconImagePath) &&
+            (identical(other.privacyPolicyUrl, privacyPolicyUrl) ||
+                other.privacyPolicyUrl == privacyPolicyUrl) &&
+            (identical(other.termsOfServiceUrl, termsOfServiceUrl) ||
+                other.termsOfServiceUrl == termsOfServiceUrl) &&
+            (identical(other.contactUrl, contactUrl) ||
+                other.contactUrl == contactUrl));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      appName,
+      packageName,
+      version,
+      buildNumber,
+      copyRight,
+      iconImagePath,
+      privacyPolicyUrl,
+      termsOfServiceUrl,
+      contactUrl);
+
+  @override
+  String toString() {
+    return 'AppInfo(appName: $appName, packageName: $packageName, version: $version, buildNumber: $buildNumber, copyRight: $copyRight, iconImagePath: $iconImagePath, privacyPolicyUrl: $privacyPolicyUrl, termsOfServiceUrl: $termsOfServiceUrl, contactUrl: $contactUrl)';
   }
 }
 
 /// @nodoc
-abstract class _$$AppInfoImplCopyWith<$Res> implements $AppInfoCopyWith<$Res> {
-  factory _$$AppInfoImplCopyWith(
-          _$AppInfoImpl value, $Res Function(_$AppInfoImpl) then) =
-      __$$AppInfoImplCopyWithImpl<$Res>;
-  @override
+abstract mixin class $AppInfoCopyWith<$Res> {
+  factory $AppInfoCopyWith(AppInfo value, $Res Function(AppInfo) _then) =
+      _$AppInfoCopyWithImpl;
   @useResult
   $Res call(
       {String appName,
@@ -148,13 +109,14 @@ abstract class _$$AppInfoImplCopyWith<$Res> implements $AppInfoCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$AppInfoImplCopyWithImpl<$Res>
-    extends _$AppInfoCopyWithImpl<$Res, _$AppInfoImpl>
-    implements _$$AppInfoImplCopyWith<$Res> {
-  __$$AppInfoImplCopyWithImpl(
-      _$AppInfoImpl _value, $Res Function(_$AppInfoImpl) _then)
-      : super(_value, _then);
+class _$AppInfoCopyWithImpl<$Res> implements $AppInfoCopyWith<$Res> {
+  _$AppInfoCopyWithImpl(this._self, this._then);
 
+  final AppInfo _self;
+  final $Res Function(AppInfo) _then;
+
+  /// Create a copy of AppInfo
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -168,41 +130,41 @@ class __$$AppInfoImplCopyWithImpl<$Res>
     Object? termsOfServiceUrl = null,
     Object? contactUrl = null,
   }) {
-    return _then(_$AppInfoImpl(
+    return _then(_self.copyWith(
       appName: null == appName
-          ? _value.appName
+          ? _self.appName
           : appName // ignore: cast_nullable_to_non_nullable
               as String,
       packageName: null == packageName
-          ? _value.packageName
+          ? _self.packageName
           : packageName // ignore: cast_nullable_to_non_nullable
               as String,
       version: null == version
-          ? _value.version
+          ? _self.version
           : version // ignore: cast_nullable_to_non_nullable
               as String,
       buildNumber: null == buildNumber
-          ? _value.buildNumber
+          ? _self.buildNumber
           : buildNumber // ignore: cast_nullable_to_non_nullable
               as String,
       copyRight: null == copyRight
-          ? _value.copyRight
+          ? _self.copyRight
           : copyRight // ignore: cast_nullable_to_non_nullable
               as String,
       iconImagePath: null == iconImagePath
-          ? _value.iconImagePath
+          ? _self.iconImagePath
           : iconImagePath // ignore: cast_nullable_to_non_nullable
               as String,
       privacyPolicyUrl: null == privacyPolicyUrl
-          ? _value.privacyPolicyUrl
+          ? _self.privacyPolicyUrl
           : privacyPolicyUrl // ignore: cast_nullable_to_non_nullable
               as Uri,
       termsOfServiceUrl: null == termsOfServiceUrl
-          ? _value.termsOfServiceUrl
+          ? _self.termsOfServiceUrl
           : termsOfServiceUrl // ignore: cast_nullable_to_non_nullable
               as Uri,
       contactUrl: null == contactUrl
-          ? _value.contactUrl
+          ? _self.contactUrl
           : contactUrl // ignore: cast_nullable_to_non_nullable
               as Uri,
     ));
@@ -211,8 +173,8 @@ class __$$AppInfoImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$AppInfoImpl extends _AppInfo {
-  const _$AppInfoImpl(
+class _AppInfo extends AppInfo {
+  const _AppInfo(
       {required this.appName,
       required this.packageName,
       required this.version,
@@ -260,16 +222,19 @@ class _$AppInfoImpl extends _AppInfo {
   @override
   final Uri contactUrl;
 
+  /// Create a copy of AppInfo
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  String toString() {
-    return 'AppInfo(appName: $appName, packageName: $packageName, version: $version, buildNumber: $buildNumber, copyRight: $copyRight, iconImagePath: $iconImagePath, privacyPolicyUrl: $privacyPolicyUrl, termsOfServiceUrl: $termsOfServiceUrl, contactUrl: $contactUrl)';
-  }
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$AppInfoCopyWith<_AppInfo> get copyWith =>
+      __$AppInfoCopyWithImpl<_AppInfo>(this, _$identity);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$AppInfoImpl &&
+            other is _AppInfo &&
             (identical(other.appName, appName) || other.appName == appName) &&
             (identical(other.packageName, packageName) ||
                 other.packageName == packageName) &&
@@ -301,64 +266,91 @@ class _$AppInfoImpl extends _AppInfo {
       termsOfServiceUrl,
       contactUrl);
 
-  @JsonKey(ignore: true)
+  @override
+  String toString() {
+    return 'AppInfo(appName: $appName, packageName: $packageName, version: $version, buildNumber: $buildNumber, copyRight: $copyRight, iconImagePath: $iconImagePath, privacyPolicyUrl: $privacyPolicyUrl, termsOfServiceUrl: $termsOfServiceUrl, contactUrl: $contactUrl)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$AppInfoCopyWith<$Res> implements $AppInfoCopyWith<$Res> {
+  factory _$AppInfoCopyWith(_AppInfo value, $Res Function(_AppInfo) _then) =
+      __$AppInfoCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String appName,
+      String packageName,
+      String version,
+      String buildNumber,
+      String copyRight,
+      String iconImagePath,
+      Uri privacyPolicyUrl,
+      Uri termsOfServiceUrl,
+      Uri contactUrl});
+}
+
+/// @nodoc
+class __$AppInfoCopyWithImpl<$Res> implements _$AppInfoCopyWith<$Res> {
+  __$AppInfoCopyWithImpl(this._self, this._then);
+
+  final _AppInfo _self;
+  final $Res Function(_AppInfo) _then;
+
+  /// Create a copy of AppInfo
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
-  _$$AppInfoImplCopyWith<_$AppInfoImpl> get copyWith =>
-      __$$AppInfoImplCopyWithImpl<_$AppInfoImpl>(this, _$identity);
+  $Res call({
+    Object? appName = null,
+    Object? packageName = null,
+    Object? version = null,
+    Object? buildNumber = null,
+    Object? copyRight = null,
+    Object? iconImagePath = null,
+    Object? privacyPolicyUrl = null,
+    Object? termsOfServiceUrl = null,
+    Object? contactUrl = null,
+  }) {
+    return _then(_AppInfo(
+      appName: null == appName
+          ? _self.appName
+          : appName // ignore: cast_nullable_to_non_nullable
+              as String,
+      packageName: null == packageName
+          ? _self.packageName
+          : packageName // ignore: cast_nullable_to_non_nullable
+              as String,
+      version: null == version
+          ? _self.version
+          : version // ignore: cast_nullable_to_non_nullable
+              as String,
+      buildNumber: null == buildNumber
+          ? _self.buildNumber
+          : buildNumber // ignore: cast_nullable_to_non_nullable
+              as String,
+      copyRight: null == copyRight
+          ? _self.copyRight
+          : copyRight // ignore: cast_nullable_to_non_nullable
+              as String,
+      iconImagePath: null == iconImagePath
+          ? _self.iconImagePath
+          : iconImagePath // ignore: cast_nullable_to_non_nullable
+              as String,
+      privacyPolicyUrl: null == privacyPolicyUrl
+          ? _self.privacyPolicyUrl
+          : privacyPolicyUrl // ignore: cast_nullable_to_non_nullable
+              as Uri,
+      termsOfServiceUrl: null == termsOfServiceUrl
+          ? _self.termsOfServiceUrl
+          : termsOfServiceUrl // ignore: cast_nullable_to_non_nullable
+              as Uri,
+      contactUrl: null == contactUrl
+          ? _self.contactUrl
+          : contactUrl // ignore: cast_nullable_to_non_nullable
+              as Uri,
+    ));
+  }
 }
 
-abstract class _AppInfo extends AppInfo {
-  const factory _AppInfo(
-      {required final String appName,
-      required final String packageName,
-      required final String version,
-      required final String buildNumber,
-      required final String copyRight,
-      required final String iconImagePath,
-      required final Uri privacyPolicyUrl,
-      required final Uri termsOfServiceUrl,
-      required final Uri contactUrl}) = _$AppInfoImpl;
-  const _AppInfo._() : super._();
-
-  @override
-
-  /// アプリ名
-  String get appName;
-  @override
-
-  /// パッケージ名
-  String get packageName;
-  @override
-
-  /// バージョン
-  String get version;
-  @override
-
-  /// ビルド番号
-  String get buildNumber;
-  @override
-
-  /// CopyRight
-  String get copyRight;
-  @override
-
-  /// アイコン画像へのパス
-  String get iconImagePath;
-  @override
-
-  /// プライバシーポリシーのURL
-  Uri get privacyPolicyUrl;
-  @override
-
-  /// 利用規約のURL
-  Uri get termsOfServiceUrl;
-  @override
-
-  /// コンタクトのURL
-  Uri get contactUrl;
-  @override
-  @JsonKey(ignore: true)
-  _$$AppInfoImplCopyWith<_$AppInfoImpl> get copyWith =>
-      throw _privateConstructorUsedError;
-}
+// dart format on

--- a/lib/domain/app_user.dart
+++ b/lib/domain/app_user.dart
@@ -4,7 +4,7 @@ part 'app_user.freezed.dart';
 
 /// ユーザー
 @freezed
-class AppUser with _$AppUser {
+abstract class AppUser with _$AppUser {
   const factory AppUser({
     /// Auth の uid
     required String uid,

--- a/lib/domain/app_user.freezed.dart
+++ b/lib/domain/app_user.freezed.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
@@ -9,86 +10,65 @@ part of 'app_user.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
 
 /// @nodoc
 mixin _$AppUser {
   /// Auth の uid
-  String get uid => throw _privateConstructorUsedError;
+  String get uid;
 
   /// 表示名
-  String get displayName => throw _privateConstructorUsedError;
+  String get displayName;
 
   /// プロフィール画像の URL
-  String get imageUrl => throw _privateConstructorUsedError;
+  String get imageUrl;
 
-  @JsonKey(ignore: true)
-  $AppUserCopyWith<AppUser> get copyWith => throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $AppUserCopyWith<$Res> {
-  factory $AppUserCopyWith(AppUser value, $Res Function(AppUser) then) =
-      _$AppUserCopyWithImpl<$Res, AppUser>;
-  @useResult
-  $Res call({String uid, String displayName, String imageUrl});
-}
-
-/// @nodoc
-class _$AppUserCopyWithImpl<$Res, $Val extends AppUser>
-    implements $AppUserCopyWith<$Res> {
-  _$AppUserCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
+  /// Create a copy of AppUser
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @pragma('vm:prefer-inline')
+  $AppUserCopyWith<AppUser> get copyWith =>
+      _$AppUserCopyWithImpl<AppUser>(this as AppUser, _$identity);
+
   @override
-  $Res call({
-    Object? uid = null,
-    Object? displayName = null,
-    Object? imageUrl = null,
-  }) {
-    return _then(_value.copyWith(
-      uid: null == uid
-          ? _value.uid
-          : uid // ignore: cast_nullable_to_non_nullable
-              as String,
-      displayName: null == displayName
-          ? _value.displayName
-          : displayName // ignore: cast_nullable_to_non_nullable
-              as String,
-      imageUrl: null == imageUrl
-          ? _value.imageUrl
-          : imageUrl // ignore: cast_nullable_to_non_nullable
-              as String,
-    ) as $Val);
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is AppUser &&
+            (identical(other.uid, uid) || other.uid == uid) &&
+            (identical(other.displayName, displayName) ||
+                other.displayName == displayName) &&
+            (identical(other.imageUrl, imageUrl) ||
+                other.imageUrl == imageUrl));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, uid, displayName, imageUrl);
+
+  @override
+  String toString() {
+    return 'AppUser(uid: $uid, displayName: $displayName, imageUrl: $imageUrl)';
   }
 }
 
 /// @nodoc
-abstract class _$$AppUserImplCopyWith<$Res> implements $AppUserCopyWith<$Res> {
-  factory _$$AppUserImplCopyWith(
-          _$AppUserImpl value, $Res Function(_$AppUserImpl) then) =
-      __$$AppUserImplCopyWithImpl<$Res>;
-  @override
+abstract mixin class $AppUserCopyWith<$Res> {
+  factory $AppUserCopyWith(AppUser value, $Res Function(AppUser) _then) =
+      _$AppUserCopyWithImpl;
   @useResult
   $Res call({String uid, String displayName, String imageUrl});
 }
 
 /// @nodoc
-class __$$AppUserImplCopyWithImpl<$Res>
-    extends _$AppUserCopyWithImpl<$Res, _$AppUserImpl>
-    implements _$$AppUserImplCopyWith<$Res> {
-  __$$AppUserImplCopyWithImpl(
-      _$AppUserImpl _value, $Res Function(_$AppUserImpl) _then)
-      : super(_value, _then);
+class _$AppUserCopyWithImpl<$Res> implements $AppUserCopyWith<$Res> {
+  _$AppUserCopyWithImpl(this._self, this._then);
 
+  final AppUser _self;
+  final $Res Function(AppUser) _then;
+
+  /// Create a copy of AppUser
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -96,17 +76,17 @@ class __$$AppUserImplCopyWithImpl<$Res>
     Object? displayName = null,
     Object? imageUrl = null,
   }) {
-    return _then(_$AppUserImpl(
+    return _then(_self.copyWith(
       uid: null == uid
-          ? _value.uid
+          ? _self.uid
           : uid // ignore: cast_nullable_to_non_nullable
               as String,
       displayName: null == displayName
-          ? _value.displayName
+          ? _self.displayName
           : displayName // ignore: cast_nullable_to_non_nullable
               as String,
       imageUrl: null == imageUrl
-          ? _value.imageUrl
+          ? _self.imageUrl
           : imageUrl // ignore: cast_nullable_to_non_nullable
               as String,
     ));
@@ -115,8 +95,8 @@ class __$$AppUserImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$AppUserImpl implements _AppUser {
-  const _$AppUserImpl(
+class _AppUser implements AppUser {
+  const _AppUser(
       {required this.uid, required this.displayName, required this.imageUrl});
 
   /// Auth の uid
@@ -131,16 +111,19 @@ class _$AppUserImpl implements _AppUser {
   @override
   final String imageUrl;
 
+  /// Create a copy of AppUser
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  String toString() {
-    return 'AppUser(uid: $uid, displayName: $displayName, imageUrl: $imageUrl)';
-  }
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$AppUserCopyWith<_AppUser> get copyWith =>
+      __$AppUserCopyWithImpl<_AppUser>(this, _$identity);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$AppUserImpl &&
+            other is _AppUser &&
             (identical(other.uid, uid) || other.uid == uid) &&
             (identical(other.displayName, displayName) ||
                 other.displayName == displayName) &&
@@ -151,33 +134,52 @@ class _$AppUserImpl implements _AppUser {
   @override
   int get hashCode => Object.hash(runtimeType, uid, displayName, imageUrl);
 
-  @JsonKey(ignore: true)
+  @override
+  String toString() {
+    return 'AppUser(uid: $uid, displayName: $displayName, imageUrl: $imageUrl)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$AppUserCopyWith<$Res> implements $AppUserCopyWith<$Res> {
+  factory _$AppUserCopyWith(_AppUser value, $Res Function(_AppUser) _then) =
+      __$AppUserCopyWithImpl;
+  @override
+  @useResult
+  $Res call({String uid, String displayName, String imageUrl});
+}
+
+/// @nodoc
+class __$AppUserCopyWithImpl<$Res> implements _$AppUserCopyWith<$Res> {
+  __$AppUserCopyWithImpl(this._self, this._then);
+
+  final _AppUser _self;
+  final $Res Function(_AppUser) _then;
+
+  /// Create a copy of AppUser
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
-  _$$AppUserImplCopyWith<_$AppUserImpl> get copyWith =>
-      __$$AppUserImplCopyWithImpl<_$AppUserImpl>(this, _$identity);
+  $Res call({
+    Object? uid = null,
+    Object? displayName = null,
+    Object? imageUrl = null,
+  }) {
+    return _then(_AppUser(
+      uid: null == uid
+          ? _self.uid
+          : uid // ignore: cast_nullable_to_non_nullable
+              as String,
+      displayName: null == displayName
+          ? _self.displayName
+          : displayName // ignore: cast_nullable_to_non_nullable
+              as String,
+      imageUrl: null == imageUrl
+          ? _self.imageUrl
+          : imageUrl // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
 }
 
-abstract class _AppUser implements AppUser {
-  const factory _AppUser(
-      {required final String uid,
-      required final String displayName,
-      required final String imageUrl}) = _$AppUserImpl;
-
-  @override
-
-  /// Auth の uid
-  String get uid;
-  @override
-
-  /// 表示名
-  String get displayName;
-  @override
-
-  /// プロフィール画像の URL
-  String get imageUrl;
-  @override
-  @JsonKey(ignore: true)
-  _$$AppUserImplCopyWith<_$AppUserImpl> get copyWith =>
-      throw _privateConstructorUsedError;
-}
+// dart format on

--- a/lib/domain/conf.dart
+++ b/lib/domain/conf.dart
@@ -4,7 +4,7 @@ part 'conf.freezed.dart';
 
 /// ユーザー Conf
 @freezed
-class Conf with _$Conf {
+abstract class Conf with _$Conf {
   const factory Conf({
     /// Conf ID
     required String confId,

--- a/lib/domain/conf.freezed.dart
+++ b/lib/domain/conf.freezed.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
@@ -9,85 +10,66 @@ part of 'conf.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
 
 /// @nodoc
 mixin _$Conf {
   /// Conf ID
-  String get confId => throw _privateConstructorUsedError;
+  String get confId;
 
   /// ユーザーが入力できる最大の予定数
-  int get maxPlannedVolume => throw _privateConstructorUsedError;
+  int get maxPlannedVolume;
 
   /// オンボーディング完了済みかどうか
-  bool get isOnboardingCompleted => throw _privateConstructorUsedError;
+  bool get isOnboardingCompleted;
 
-  @JsonKey(ignore: true)
-  $ConfCopyWith<Conf> get copyWith => throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $ConfCopyWith<$Res> {
-  factory $ConfCopyWith(Conf value, $Res Function(Conf) then) =
-      _$ConfCopyWithImpl<$Res, Conf>;
-  @useResult
-  $Res call({String confId, int maxPlannedVolume, bool isOnboardingCompleted});
-}
-
-/// @nodoc
-class _$ConfCopyWithImpl<$Res, $Val extends Conf>
-    implements $ConfCopyWith<$Res> {
-  _$ConfCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
+  /// Create a copy of Conf
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @pragma('vm:prefer-inline')
+  $ConfCopyWith<Conf> get copyWith =>
+      _$ConfCopyWithImpl<Conf>(this as Conf, _$identity);
+
   @override
-  $Res call({
-    Object? confId = null,
-    Object? maxPlannedVolume = null,
-    Object? isOnboardingCompleted = null,
-  }) {
-    return _then(_value.copyWith(
-      confId: null == confId
-          ? _value.confId
-          : confId // ignore: cast_nullable_to_non_nullable
-              as String,
-      maxPlannedVolume: null == maxPlannedVolume
-          ? _value.maxPlannedVolume
-          : maxPlannedVolume // ignore: cast_nullable_to_non_nullable
-              as int,
-      isOnboardingCompleted: null == isOnboardingCompleted
-          ? _value.isOnboardingCompleted
-          : isOnboardingCompleted // ignore: cast_nullable_to_non_nullable
-              as bool,
-    ) as $Val);
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is Conf &&
+            (identical(other.confId, confId) || other.confId == confId) &&
+            (identical(other.maxPlannedVolume, maxPlannedVolume) ||
+                other.maxPlannedVolume == maxPlannedVolume) &&
+            (identical(other.isOnboardingCompleted, isOnboardingCompleted) ||
+                other.isOnboardingCompleted == isOnboardingCompleted));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, confId, maxPlannedVolume, isOnboardingCompleted);
+
+  @override
+  String toString() {
+    return 'Conf(confId: $confId, maxPlannedVolume: $maxPlannedVolume, isOnboardingCompleted: $isOnboardingCompleted)';
   }
 }
 
 /// @nodoc
-abstract class _$$ConfImplCopyWith<$Res> implements $ConfCopyWith<$Res> {
-  factory _$$ConfImplCopyWith(
-          _$ConfImpl value, $Res Function(_$ConfImpl) then) =
-      __$$ConfImplCopyWithImpl<$Res>;
-  @override
+abstract mixin class $ConfCopyWith<$Res> {
+  factory $ConfCopyWith(Conf value, $Res Function(Conf) _then) =
+      _$ConfCopyWithImpl;
   @useResult
   $Res call({String confId, int maxPlannedVolume, bool isOnboardingCompleted});
 }
 
 /// @nodoc
-class __$$ConfImplCopyWithImpl<$Res>
-    extends _$ConfCopyWithImpl<$Res, _$ConfImpl>
-    implements _$$ConfImplCopyWith<$Res> {
-  __$$ConfImplCopyWithImpl(_$ConfImpl _value, $Res Function(_$ConfImpl) _then)
-      : super(_value, _then);
+class _$ConfCopyWithImpl<$Res> implements $ConfCopyWith<$Res> {
+  _$ConfCopyWithImpl(this._self, this._then);
 
+  final Conf _self;
+  final $Res Function(Conf) _then;
+
+  /// Create a copy of Conf
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -95,17 +77,17 @@ class __$$ConfImplCopyWithImpl<$Res>
     Object? maxPlannedVolume = null,
     Object? isOnboardingCompleted = null,
   }) {
-    return _then(_$ConfImpl(
+    return _then(_self.copyWith(
       confId: null == confId
-          ? _value.confId
+          ? _self.confId
           : confId // ignore: cast_nullable_to_non_nullable
               as String,
       maxPlannedVolume: null == maxPlannedVolume
-          ? _value.maxPlannedVolume
+          ? _self.maxPlannedVolume
           : maxPlannedVolume // ignore: cast_nullable_to_non_nullable
               as int,
       isOnboardingCompleted: null == isOnboardingCompleted
-          ? _value.isOnboardingCompleted
+          ? _self.isOnboardingCompleted
           : isOnboardingCompleted // ignore: cast_nullable_to_non_nullable
               as bool,
     ));
@@ -114,8 +96,8 @@ class __$$ConfImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$ConfImpl implements _Conf {
-  const _$ConfImpl(
+class _Conf implements Conf {
+  const _Conf(
       {required this.confId,
       required this.maxPlannedVolume,
       required this.isOnboardingCompleted});
@@ -132,16 +114,19 @@ class _$ConfImpl implements _Conf {
   @override
   final bool isOnboardingCompleted;
 
+  /// Create a copy of Conf
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  String toString() {
-    return 'Conf(confId: $confId, maxPlannedVolume: $maxPlannedVolume, isOnboardingCompleted: $isOnboardingCompleted)';
-  }
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$ConfCopyWith<_Conf> get copyWith =>
+      __$ConfCopyWithImpl<_Conf>(this, _$identity);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$ConfImpl &&
+            other is _Conf &&
             (identical(other.confId, confId) || other.confId == confId) &&
             (identical(other.maxPlannedVolume, maxPlannedVolume) ||
                 other.maxPlannedVolume == maxPlannedVolume) &&
@@ -153,33 +138,52 @@ class _$ConfImpl implements _Conf {
   int get hashCode =>
       Object.hash(runtimeType, confId, maxPlannedVolume, isOnboardingCompleted);
 
-  @JsonKey(ignore: true)
+  @override
+  String toString() {
+    return 'Conf(confId: $confId, maxPlannedVolume: $maxPlannedVolume, isOnboardingCompleted: $isOnboardingCompleted)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$ConfCopyWith<$Res> implements $ConfCopyWith<$Res> {
+  factory _$ConfCopyWith(_Conf value, $Res Function(_Conf) _then) =
+      __$ConfCopyWithImpl;
+  @override
+  @useResult
+  $Res call({String confId, int maxPlannedVolume, bool isOnboardingCompleted});
+}
+
+/// @nodoc
+class __$ConfCopyWithImpl<$Res> implements _$ConfCopyWith<$Res> {
+  __$ConfCopyWithImpl(this._self, this._then);
+
+  final _Conf _self;
+  final $Res Function(_Conf) _then;
+
+  /// Create a copy of Conf
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
-  _$$ConfImplCopyWith<_$ConfImpl> get copyWith =>
-      __$$ConfImplCopyWithImpl<_$ConfImpl>(this, _$identity);
+  $Res call({
+    Object? confId = null,
+    Object? maxPlannedVolume = null,
+    Object? isOnboardingCompleted = null,
+  }) {
+    return _then(_Conf(
+      confId: null == confId
+          ? _self.confId
+          : confId // ignore: cast_nullable_to_non_nullable
+              as String,
+      maxPlannedVolume: null == maxPlannedVolume
+          ? _self.maxPlannedVolume
+          : maxPlannedVolume // ignore: cast_nullable_to_non_nullable
+              as int,
+      isOnboardingCompleted: null == isOnboardingCompleted
+          ? _self.isOnboardingCompleted
+          : isOnboardingCompleted // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
 }
 
-abstract class _Conf implements Conf {
-  const factory _Conf(
-      {required final String confId,
-      required final int maxPlannedVolume,
-      required final bool isOnboardingCompleted}) = _$ConfImpl;
-
-  @override
-
-  /// Conf ID
-  String get confId;
-  @override
-
-  /// ユーザーが入力できる最大の予定数
-  int get maxPlannedVolume;
-  @override
-
-  /// オンボーディング完了済みかどうか
-  bool get isOnboardingCompleted;
-  @override
-  @JsonKey(ignore: true)
-  _$$ConfImplCopyWith<_$ConfImpl> get copyWith =>
-      throw _privateConstructorUsedError;
-}
+// dart format on

--- a/lib/domain/mood_point.dart
+++ b/lib/domain/mood_point.dart
@@ -4,7 +4,7 @@ part 'mood_point.freezed.dart';
 
 /// MoodPoint コレクションのドキュメント
 @freezed
-class MoodPoint with _$MoodPoint {
+abstract class MoodPoint with _$MoodPoint {
   const factory MoodPoint({
     /// 気分値 ID
     required String pointId,

--- a/lib/domain/mood_point.freezed.dart
+++ b/lib/domain/mood_point.freezed.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
@@ -9,96 +10,70 @@ part of 'mood_point.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
 
 /// @nodoc
 mixin _$MoodPoint {
   /// 気分値 ID
-  String get pointId => throw _privateConstructorUsedError;
+  String get pointId;
 
   /// 気分値
-  int get point => throw _privateConstructorUsedError;
+  int get point;
 
   /// 予定量
-  int get plannedVolume => throw _privateConstructorUsedError;
+  int get plannedVolume;
 
   /// 気分日
-  DateTime get moodDate => throw _privateConstructorUsedError;
+  DateTime get moodDate;
 
-  @JsonKey(ignore: true)
-  $MoodPointCopyWith<MoodPoint> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $MoodPointCopyWith<$Res> {
-  factory $MoodPointCopyWith(MoodPoint value, $Res Function(MoodPoint) then) =
-      _$MoodPointCopyWithImpl<$Res, MoodPoint>;
-  @useResult
-  $Res call({String pointId, int point, int plannedVolume, DateTime moodDate});
-}
-
-/// @nodoc
-class _$MoodPointCopyWithImpl<$Res, $Val extends MoodPoint>
-    implements $MoodPointCopyWith<$Res> {
-  _$MoodPointCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
+  /// Create a copy of MoodPoint
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @pragma('vm:prefer-inline')
+  $MoodPointCopyWith<MoodPoint> get copyWith =>
+      _$MoodPointCopyWithImpl<MoodPoint>(this as MoodPoint, _$identity);
+
   @override
-  $Res call({
-    Object? pointId = null,
-    Object? point = null,
-    Object? plannedVolume = null,
-    Object? moodDate = null,
-  }) {
-    return _then(_value.copyWith(
-      pointId: null == pointId
-          ? _value.pointId
-          : pointId // ignore: cast_nullable_to_non_nullable
-              as String,
-      point: null == point
-          ? _value.point
-          : point // ignore: cast_nullable_to_non_nullable
-              as int,
-      plannedVolume: null == plannedVolume
-          ? _value.plannedVolume
-          : plannedVolume // ignore: cast_nullable_to_non_nullable
-              as int,
-      moodDate: null == moodDate
-          ? _value.moodDate
-          : moodDate // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-    ) as $Val);
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is MoodPoint &&
+            (identical(other.pointId, pointId) || other.pointId == pointId) &&
+            (identical(other.point, point) || other.point == point) &&
+            (identical(other.plannedVolume, plannedVolume) ||
+                other.plannedVolume == plannedVolume) &&
+            (identical(other.moodDate, moodDate) ||
+                other.moodDate == moodDate));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, pointId, point, plannedVolume, moodDate);
+
+  @override
+  String toString() {
+    return 'MoodPoint(pointId: $pointId, point: $point, plannedVolume: $plannedVolume, moodDate: $moodDate)';
   }
 }
 
 /// @nodoc
-abstract class _$$MoodPointImplCopyWith<$Res>
-    implements $MoodPointCopyWith<$Res> {
-  factory _$$MoodPointImplCopyWith(
-          _$MoodPointImpl value, $Res Function(_$MoodPointImpl) then) =
-      __$$MoodPointImplCopyWithImpl<$Res>;
-  @override
+abstract mixin class $MoodPointCopyWith<$Res> {
+  factory $MoodPointCopyWith(MoodPoint value, $Res Function(MoodPoint) _then) =
+      _$MoodPointCopyWithImpl;
   @useResult
   $Res call({String pointId, int point, int plannedVolume, DateTime moodDate});
 }
 
 /// @nodoc
-class __$$MoodPointImplCopyWithImpl<$Res>
-    extends _$MoodPointCopyWithImpl<$Res, _$MoodPointImpl>
-    implements _$$MoodPointImplCopyWith<$Res> {
-  __$$MoodPointImplCopyWithImpl(
-      _$MoodPointImpl _value, $Res Function(_$MoodPointImpl) _then)
-      : super(_value, _then);
+class _$MoodPointCopyWithImpl<$Res> implements $MoodPointCopyWith<$Res> {
+  _$MoodPointCopyWithImpl(this._self, this._then);
 
+  final MoodPoint _self;
+  final $Res Function(MoodPoint) _then;
+
+  /// Create a copy of MoodPoint
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -107,21 +82,21 @@ class __$$MoodPointImplCopyWithImpl<$Res>
     Object? plannedVolume = null,
     Object? moodDate = null,
   }) {
-    return _then(_$MoodPointImpl(
+    return _then(_self.copyWith(
       pointId: null == pointId
-          ? _value.pointId
+          ? _self.pointId
           : pointId // ignore: cast_nullable_to_non_nullable
               as String,
       point: null == point
-          ? _value.point
+          ? _self.point
           : point // ignore: cast_nullable_to_non_nullable
               as int,
       plannedVolume: null == plannedVolume
-          ? _value.plannedVolume
+          ? _self.plannedVolume
           : plannedVolume // ignore: cast_nullable_to_non_nullable
               as int,
       moodDate: null == moodDate
-          ? _value.moodDate
+          ? _self.moodDate
           : moodDate // ignore: cast_nullable_to_non_nullable
               as DateTime,
     ));
@@ -130,8 +105,8 @@ class __$$MoodPointImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$MoodPointImpl implements _MoodPoint {
-  const _$MoodPointImpl(
+class _MoodPoint implements MoodPoint {
+  const _MoodPoint(
       {required this.pointId,
       required this.point,
       required this.plannedVolume,
@@ -153,16 +128,19 @@ class _$MoodPointImpl implements _MoodPoint {
   @override
   final DateTime moodDate;
 
+  /// Create a copy of MoodPoint
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  String toString() {
-    return 'MoodPoint(pointId: $pointId, point: $point, plannedVolume: $plannedVolume, moodDate: $moodDate)';
-  }
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$MoodPointCopyWith<_MoodPoint> get copyWith =>
+      __$MoodPointCopyWithImpl<_MoodPoint>(this, _$identity);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$MoodPointImpl &&
+            other is _MoodPoint &&
             (identical(other.pointId, pointId) || other.pointId == pointId) &&
             (identical(other.point, point) || other.point == point) &&
             (identical(other.plannedVolume, plannedVolume) ||
@@ -175,38 +153,59 @@ class _$MoodPointImpl implements _MoodPoint {
   int get hashCode =>
       Object.hash(runtimeType, pointId, point, plannedVolume, moodDate);
 
-  @JsonKey(ignore: true)
+  @override
+  String toString() {
+    return 'MoodPoint(pointId: $pointId, point: $point, plannedVolume: $plannedVolume, moodDate: $moodDate)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$MoodPointCopyWith<$Res>
+    implements $MoodPointCopyWith<$Res> {
+  factory _$MoodPointCopyWith(
+          _MoodPoint value, $Res Function(_MoodPoint) _then) =
+      __$MoodPointCopyWithImpl;
+  @override
+  @useResult
+  $Res call({String pointId, int point, int plannedVolume, DateTime moodDate});
+}
+
+/// @nodoc
+class __$MoodPointCopyWithImpl<$Res> implements _$MoodPointCopyWith<$Res> {
+  __$MoodPointCopyWithImpl(this._self, this._then);
+
+  final _MoodPoint _self;
+  final $Res Function(_MoodPoint) _then;
+
+  /// Create a copy of MoodPoint
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
-  _$$MoodPointImplCopyWith<_$MoodPointImpl> get copyWith =>
-      __$$MoodPointImplCopyWithImpl<_$MoodPointImpl>(this, _$identity);
+  $Res call({
+    Object? pointId = null,
+    Object? point = null,
+    Object? plannedVolume = null,
+    Object? moodDate = null,
+  }) {
+    return _then(_MoodPoint(
+      pointId: null == pointId
+          ? _self.pointId
+          : pointId // ignore: cast_nullable_to_non_nullable
+              as String,
+      point: null == point
+          ? _self.point
+          : point // ignore: cast_nullable_to_non_nullable
+              as int,
+      plannedVolume: null == plannedVolume
+          ? _self.plannedVolume
+          : plannedVolume // ignore: cast_nullable_to_non_nullable
+              as int,
+      moodDate: null == moodDate
+          ? _self.moodDate
+          : moodDate // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+    ));
+  }
 }
 
-abstract class _MoodPoint implements MoodPoint {
-  const factory _MoodPoint(
-      {required final String pointId,
-      required final int point,
-      required final int plannedVolume,
-      required final DateTime moodDate}) = _$MoodPointImpl;
-
-  @override
-
-  /// 気分値 ID
-  String get pointId;
-  @override
-
-  /// 気分値
-  int get point;
-  @override
-
-  /// 予定量
-  int get plannedVolume;
-  @override
-
-  /// 気分日
-  DateTime get moodDate;
-  @override
-  @JsonKey(ignore: true)
-  _$$MoodPointImplCopyWith<_$MoodPointImpl> get copyWith =>
-      throw _privateConstructorUsedError;
-}
+// dart format on

--- a/lib/domain/mood_worksheet.dart
+++ b/lib/domain/mood_worksheet.dart
@@ -4,7 +4,7 @@ part 'mood_worksheet.freezed.dart';
 
 /// 気分値目安表
 @freezed
-class MoodWorksheet with _$MoodWorksheet {
+abstract class MoodWorksheet with _$MoodWorksheet {
   const factory MoodWorksheet({
     /// ワークシート ID
     required String worksheetId,

--- a/lib/domain/mood_worksheet.freezed.dart
+++ b/lib/domain/mood_worksheet.freezed.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
@@ -9,152 +10,86 @@ part of 'mood_worksheet.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
 
 /// @nodoc
 mixin _$MoodWorksheet {
   /// ワークシート ID
-  String get worksheetId => throw _privateConstructorUsedError;
+  String get worksheetId;
 
   /// -5
-  String get minus_5 => throw _privateConstructorUsedError;
+  String get minus_5;
 
   /// -4
-  String get minus_4 => throw _privateConstructorUsedError;
+  String get minus_4;
 
   /// -3
-  String get minus_3 => throw _privateConstructorUsedError;
+  String get minus_3;
 
   /// -2
-  String get minus_2 => throw _privateConstructorUsedError;
+  String get minus_2;
 
   /// -1
-  String get minus_1 => throw _privateConstructorUsedError;
+  String get minus_1;
 
   /// +1
-  String get plus_1 => throw _privateConstructorUsedError;
+  String get plus_1;
 
   /// +2
-  String get plus_2 => throw _privateConstructorUsedError;
+  String get plus_2;
 
   /// +3
-  String get plus_3 => throw _privateConstructorUsedError;
+  String get plus_3;
 
   /// +4
-  String get plus_4 => throw _privateConstructorUsedError;
+  String get plus_4;
 
   /// +5
-  String get plus_5 => throw _privateConstructorUsedError;
+  String get plus_5;
 
-  @JsonKey(ignore: true)
-  $MoodWorksheetCopyWith<MoodWorksheet> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $MoodWorksheetCopyWith<$Res> {
-  factory $MoodWorksheetCopyWith(
-          MoodWorksheet value, $Res Function(MoodWorksheet) then) =
-      _$MoodWorksheetCopyWithImpl<$Res, MoodWorksheet>;
-  @useResult
-  $Res call(
-      {String worksheetId,
-      String minus_5,
-      String minus_4,
-      String minus_3,
-      String minus_2,
-      String minus_1,
-      String plus_1,
-      String plus_2,
-      String plus_3,
-      String plus_4,
-      String plus_5});
-}
-
-/// @nodoc
-class _$MoodWorksheetCopyWithImpl<$Res, $Val extends MoodWorksheet>
-    implements $MoodWorksheetCopyWith<$Res> {
-  _$MoodWorksheetCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
+  /// Create a copy of MoodWorksheet
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @pragma('vm:prefer-inline')
+  $MoodWorksheetCopyWith<MoodWorksheet> get copyWith =>
+      _$MoodWorksheetCopyWithImpl<MoodWorksheet>(
+          this as MoodWorksheet, _$identity);
+
   @override
-  $Res call({
-    Object? worksheetId = null,
-    Object? minus_5 = null,
-    Object? minus_4 = null,
-    Object? minus_3 = null,
-    Object? minus_2 = null,
-    Object? minus_1 = null,
-    Object? plus_1 = null,
-    Object? plus_2 = null,
-    Object? plus_3 = null,
-    Object? plus_4 = null,
-    Object? plus_5 = null,
-  }) {
-    return _then(_value.copyWith(
-      worksheetId: null == worksheetId
-          ? _value.worksheetId
-          : worksheetId // ignore: cast_nullable_to_non_nullable
-              as String,
-      minus_5: null == minus_5
-          ? _value.minus_5
-          : minus_5 // ignore: cast_nullable_to_non_nullable
-              as String,
-      minus_4: null == minus_4
-          ? _value.minus_4
-          : minus_4 // ignore: cast_nullable_to_non_nullable
-              as String,
-      minus_3: null == minus_3
-          ? _value.minus_3
-          : minus_3 // ignore: cast_nullable_to_non_nullable
-              as String,
-      minus_2: null == minus_2
-          ? _value.minus_2
-          : minus_2 // ignore: cast_nullable_to_non_nullable
-              as String,
-      minus_1: null == minus_1
-          ? _value.minus_1
-          : minus_1 // ignore: cast_nullable_to_non_nullable
-              as String,
-      plus_1: null == plus_1
-          ? _value.plus_1
-          : plus_1 // ignore: cast_nullable_to_non_nullable
-              as String,
-      plus_2: null == plus_2
-          ? _value.plus_2
-          : plus_2 // ignore: cast_nullable_to_non_nullable
-              as String,
-      plus_3: null == plus_3
-          ? _value.plus_3
-          : plus_3 // ignore: cast_nullable_to_non_nullable
-              as String,
-      plus_4: null == plus_4
-          ? _value.plus_4
-          : plus_4 // ignore: cast_nullable_to_non_nullable
-              as String,
-      plus_5: null == plus_5
-          ? _value.plus_5
-          : plus_5 // ignore: cast_nullable_to_non_nullable
-              as String,
-    ) as $Val);
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is MoodWorksheet &&
+            (identical(other.worksheetId, worksheetId) ||
+                other.worksheetId == worksheetId) &&
+            (identical(other.minus_5, minus_5) || other.minus_5 == minus_5) &&
+            (identical(other.minus_4, minus_4) || other.minus_4 == minus_4) &&
+            (identical(other.minus_3, minus_3) || other.minus_3 == minus_3) &&
+            (identical(other.minus_2, minus_2) || other.minus_2 == minus_2) &&
+            (identical(other.minus_1, minus_1) || other.minus_1 == minus_1) &&
+            (identical(other.plus_1, plus_1) || other.plus_1 == plus_1) &&
+            (identical(other.plus_2, plus_2) || other.plus_2 == plus_2) &&
+            (identical(other.plus_3, plus_3) || other.plus_3 == plus_3) &&
+            (identical(other.plus_4, plus_4) || other.plus_4 == plus_4) &&
+            (identical(other.plus_5, plus_5) || other.plus_5 == plus_5));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, worksheetId, minus_5, minus_4,
+      minus_3, minus_2, minus_1, plus_1, plus_2, plus_3, plus_4, plus_5);
+
+  @override
+  String toString() {
+    return 'MoodWorksheet(worksheetId: $worksheetId, minus_5: $minus_5, minus_4: $minus_4, minus_3: $minus_3, minus_2: $minus_2, minus_1: $minus_1, plus_1: $plus_1, plus_2: $plus_2, plus_3: $plus_3, plus_4: $plus_4, plus_5: $plus_5)';
   }
 }
 
 /// @nodoc
-abstract class _$$MoodWorksheetImplCopyWith<$Res>
-    implements $MoodWorksheetCopyWith<$Res> {
-  factory _$$MoodWorksheetImplCopyWith(
-          _$MoodWorksheetImpl value, $Res Function(_$MoodWorksheetImpl) then) =
-      __$$MoodWorksheetImplCopyWithImpl<$Res>;
-  @override
+abstract mixin class $MoodWorksheetCopyWith<$Res> {
+  factory $MoodWorksheetCopyWith(
+          MoodWorksheet value, $Res Function(MoodWorksheet) _then) =
+      _$MoodWorksheetCopyWithImpl;
   @useResult
   $Res call(
       {String worksheetId,
@@ -171,13 +106,15 @@ abstract class _$$MoodWorksheetImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$MoodWorksheetImplCopyWithImpl<$Res>
-    extends _$MoodWorksheetCopyWithImpl<$Res, _$MoodWorksheetImpl>
-    implements _$$MoodWorksheetImplCopyWith<$Res> {
-  __$$MoodWorksheetImplCopyWithImpl(
-      _$MoodWorksheetImpl _value, $Res Function(_$MoodWorksheetImpl) _then)
-      : super(_value, _then);
+class _$MoodWorksheetCopyWithImpl<$Res>
+    implements $MoodWorksheetCopyWith<$Res> {
+  _$MoodWorksheetCopyWithImpl(this._self, this._then);
 
+  final MoodWorksheet _self;
+  final $Res Function(MoodWorksheet) _then;
+
+  /// Create a copy of MoodWorksheet
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -193,49 +130,49 @@ class __$$MoodWorksheetImplCopyWithImpl<$Res>
     Object? plus_4 = null,
     Object? plus_5 = null,
   }) {
-    return _then(_$MoodWorksheetImpl(
+    return _then(_self.copyWith(
       worksheetId: null == worksheetId
-          ? _value.worksheetId
+          ? _self.worksheetId
           : worksheetId // ignore: cast_nullable_to_non_nullable
               as String,
       minus_5: null == minus_5
-          ? _value.minus_5
+          ? _self.minus_5
           : minus_5 // ignore: cast_nullable_to_non_nullable
               as String,
       minus_4: null == minus_4
-          ? _value.minus_4
+          ? _self.minus_4
           : minus_4 // ignore: cast_nullable_to_non_nullable
               as String,
       minus_3: null == minus_3
-          ? _value.minus_3
+          ? _self.minus_3
           : minus_3 // ignore: cast_nullable_to_non_nullable
               as String,
       minus_2: null == minus_2
-          ? _value.minus_2
+          ? _self.minus_2
           : minus_2 // ignore: cast_nullable_to_non_nullable
               as String,
       minus_1: null == minus_1
-          ? _value.minus_1
+          ? _self.minus_1
           : minus_1 // ignore: cast_nullable_to_non_nullable
               as String,
       plus_1: null == plus_1
-          ? _value.plus_1
+          ? _self.plus_1
           : plus_1 // ignore: cast_nullable_to_non_nullable
               as String,
       plus_2: null == plus_2
-          ? _value.plus_2
+          ? _self.plus_2
           : plus_2 // ignore: cast_nullable_to_non_nullable
               as String,
       plus_3: null == plus_3
-          ? _value.plus_3
+          ? _self.plus_3
           : plus_3 // ignore: cast_nullable_to_non_nullable
               as String,
       plus_4: null == plus_4
-          ? _value.plus_4
+          ? _self.plus_4
           : plus_4 // ignore: cast_nullable_to_non_nullable
               as String,
       plus_5: null == plus_5
-          ? _value.plus_5
+          ? _self.plus_5
           : plus_5 // ignore: cast_nullable_to_non_nullable
               as String,
     ));
@@ -244,8 +181,8 @@ class __$$MoodWorksheetImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$MoodWorksheetImpl implements _MoodWorksheet {
-  const _$MoodWorksheetImpl(
+class _MoodWorksheet implements MoodWorksheet {
+  const _MoodWorksheet(
       {required this.worksheetId,
       required this.minus_5,
       required this.minus_4,
@@ -302,16 +239,19 @@ class _$MoodWorksheetImpl implements _MoodWorksheet {
   @override
   final String plus_5;
 
+  /// Create a copy of MoodWorksheet
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  String toString() {
-    return 'MoodWorksheet(worksheetId: $worksheetId, minus_5: $minus_5, minus_4: $minus_4, minus_3: $minus_3, minus_2: $minus_2, minus_1: $minus_1, plus_1: $plus_1, plus_2: $plus_2, plus_3: $plus_3, plus_4: $plus_4, plus_5: $plus_5)';
-  }
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$MoodWorksheetCopyWith<_MoodWorksheet> get copyWith =>
+      __$MoodWorksheetCopyWithImpl<_MoodWorksheet>(this, _$identity);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$MoodWorksheetImpl &&
+            other is _MoodWorksheet &&
             (identical(other.worksheetId, worksheetId) ||
                 other.worksheetId == worksheetId) &&
             (identical(other.minus_5, minus_5) || other.minus_5 == minus_5) &&
@@ -330,73 +270,106 @@ class _$MoodWorksheetImpl implements _MoodWorksheet {
   int get hashCode => Object.hash(runtimeType, worksheetId, minus_5, minus_4,
       minus_3, minus_2, minus_1, plus_1, plus_2, plus_3, plus_4, plus_5);
 
-  @JsonKey(ignore: true)
+  @override
+  String toString() {
+    return 'MoodWorksheet(worksheetId: $worksheetId, minus_5: $minus_5, minus_4: $minus_4, minus_3: $minus_3, minus_2: $minus_2, minus_1: $minus_1, plus_1: $plus_1, plus_2: $plus_2, plus_3: $plus_3, plus_4: $plus_4, plus_5: $plus_5)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$MoodWorksheetCopyWith<$Res>
+    implements $MoodWorksheetCopyWith<$Res> {
+  factory _$MoodWorksheetCopyWith(
+          _MoodWorksheet value, $Res Function(_MoodWorksheet) _then) =
+      __$MoodWorksheetCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String worksheetId,
+      String minus_5,
+      String minus_4,
+      String minus_3,
+      String minus_2,
+      String minus_1,
+      String plus_1,
+      String plus_2,
+      String plus_3,
+      String plus_4,
+      String plus_5});
+}
+
+/// @nodoc
+class __$MoodWorksheetCopyWithImpl<$Res>
+    implements _$MoodWorksheetCopyWith<$Res> {
+  __$MoodWorksheetCopyWithImpl(this._self, this._then);
+
+  final _MoodWorksheet _self;
+  final $Res Function(_MoodWorksheet) _then;
+
+  /// Create a copy of MoodWorksheet
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
-  _$$MoodWorksheetImplCopyWith<_$MoodWorksheetImpl> get copyWith =>
-      __$$MoodWorksheetImplCopyWithImpl<_$MoodWorksheetImpl>(this, _$identity);
+  $Res call({
+    Object? worksheetId = null,
+    Object? minus_5 = null,
+    Object? minus_4 = null,
+    Object? minus_3 = null,
+    Object? minus_2 = null,
+    Object? minus_1 = null,
+    Object? plus_1 = null,
+    Object? plus_2 = null,
+    Object? plus_3 = null,
+    Object? plus_4 = null,
+    Object? plus_5 = null,
+  }) {
+    return _then(_MoodWorksheet(
+      worksheetId: null == worksheetId
+          ? _self.worksheetId
+          : worksheetId // ignore: cast_nullable_to_non_nullable
+              as String,
+      minus_5: null == minus_5
+          ? _self.minus_5
+          : minus_5 // ignore: cast_nullable_to_non_nullable
+              as String,
+      minus_4: null == minus_4
+          ? _self.minus_4
+          : minus_4 // ignore: cast_nullable_to_non_nullable
+              as String,
+      minus_3: null == minus_3
+          ? _self.minus_3
+          : minus_3 // ignore: cast_nullable_to_non_nullable
+              as String,
+      minus_2: null == minus_2
+          ? _self.minus_2
+          : minus_2 // ignore: cast_nullable_to_non_nullable
+              as String,
+      minus_1: null == minus_1
+          ? _self.minus_1
+          : minus_1 // ignore: cast_nullable_to_non_nullable
+              as String,
+      plus_1: null == plus_1
+          ? _self.plus_1
+          : plus_1 // ignore: cast_nullable_to_non_nullable
+              as String,
+      plus_2: null == plus_2
+          ? _self.plus_2
+          : plus_2 // ignore: cast_nullable_to_non_nullable
+              as String,
+      plus_3: null == plus_3
+          ? _self.plus_3
+          : plus_3 // ignore: cast_nullable_to_non_nullable
+              as String,
+      plus_4: null == plus_4
+          ? _self.plus_4
+          : plus_4 // ignore: cast_nullable_to_non_nullable
+              as String,
+      plus_5: null == plus_5
+          ? _self.plus_5
+          : plus_5 // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
 }
 
-abstract class _MoodWorksheet implements MoodWorksheet {
-  const factory _MoodWorksheet(
-      {required final String worksheetId,
-      required final String minus_5,
-      required final String minus_4,
-      required final String minus_3,
-      required final String minus_2,
-      required final String minus_1,
-      required final String plus_1,
-      required final String plus_2,
-      required final String plus_3,
-      required final String plus_4,
-      required final String plus_5}) = _$MoodWorksheetImpl;
-
-  @override
-
-  /// ワークシート ID
-  String get worksheetId;
-  @override
-
-  /// -5
-  String get minus_5;
-  @override
-
-  /// -4
-  String get minus_4;
-  @override
-
-  /// -3
-  String get minus_3;
-  @override
-
-  /// -2
-  String get minus_2;
-  @override
-
-  /// -1
-  String get minus_1;
-  @override
-
-  /// +1
-  String get plus_1;
-  @override
-
-  /// +2
-  String get plus_2;
-  @override
-
-  /// +3
-  String get plus_3;
-  @override
-
-  /// +4
-  String get plus_4;
-  @override
-
-  /// +5
-  String get plus_5;
-  @override
-  @JsonKey(ignore: true)
-  _$$MoodWorksheetImplCopyWith<_$MoodWorksheetImpl> get copyWith =>
-      throw _privateConstructorUsedError;
-}
+// dart format on

--- a/lib/domain/url_launch_data.dart
+++ b/lib/domain/url_launch_data.dart
@@ -5,7 +5,7 @@ part 'url_launch_data.freezed.dart';
 
 /// URL起動データ
 @freezed
-class UrlLaunchData with _$UrlLaunchData {
+abstract class UrlLaunchData with _$UrlLaunchData {
   const factory UrlLaunchData({
     required String urlString,
     required LaunchMode mode,

--- a/lib/domain/url_launch_data.freezed.dart
+++ b/lib/domain/url_launch_data.freezed.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
@@ -9,118 +10,27 @@ part of 'url_launch_data.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
 
 /// @nodoc
 mixin _$UrlLaunchData {
-  String get urlString => throw _privateConstructorUsedError;
-  LaunchMode get mode => throw _privateConstructorUsedError;
+  String get urlString;
+  LaunchMode get mode;
 
-  @JsonKey(ignore: true)
+  /// Create a copy of UrlLaunchData
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
   $UrlLaunchDataCopyWith<UrlLaunchData> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $UrlLaunchDataCopyWith<$Res> {
-  factory $UrlLaunchDataCopyWith(
-          UrlLaunchData value, $Res Function(UrlLaunchData) then) =
-      _$UrlLaunchDataCopyWithImpl<$Res, UrlLaunchData>;
-  @useResult
-  $Res call({String urlString, LaunchMode mode});
-}
-
-/// @nodoc
-class _$UrlLaunchDataCopyWithImpl<$Res, $Val extends UrlLaunchData>
-    implements $UrlLaunchDataCopyWith<$Res> {
-  _$UrlLaunchDataCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? urlString = null,
-    Object? mode = null,
-  }) {
-    return _then(_value.copyWith(
-      urlString: null == urlString
-          ? _value.urlString
-          : urlString // ignore: cast_nullable_to_non_nullable
-              as String,
-      mode: null == mode
-          ? _value.mode
-          : mode // ignore: cast_nullable_to_non_nullable
-              as LaunchMode,
-    ) as $Val);
-  }
-}
-
-/// @nodoc
-abstract class _$$UrlLaunchDataImplCopyWith<$Res>
-    implements $UrlLaunchDataCopyWith<$Res> {
-  factory _$$UrlLaunchDataImplCopyWith(
-          _$UrlLaunchDataImpl value, $Res Function(_$UrlLaunchDataImpl) then) =
-      __$$UrlLaunchDataImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({String urlString, LaunchMode mode});
-}
-
-/// @nodoc
-class __$$UrlLaunchDataImplCopyWithImpl<$Res>
-    extends _$UrlLaunchDataCopyWithImpl<$Res, _$UrlLaunchDataImpl>
-    implements _$$UrlLaunchDataImplCopyWith<$Res> {
-  __$$UrlLaunchDataImplCopyWithImpl(
-      _$UrlLaunchDataImpl _value, $Res Function(_$UrlLaunchDataImpl) _then)
-      : super(_value, _then);
-
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? urlString = null,
-    Object? mode = null,
-  }) {
-    return _then(_$UrlLaunchDataImpl(
-      urlString: null == urlString
-          ? _value.urlString
-          : urlString // ignore: cast_nullable_to_non_nullable
-              as String,
-      mode: null == mode
-          ? _value.mode
-          : mode // ignore: cast_nullable_to_non_nullable
-              as LaunchMode,
-    ));
-  }
-}
-
-/// @nodoc
-
-class _$UrlLaunchDataImpl extends _UrlLaunchData {
-  const _$UrlLaunchDataImpl({required this.urlString, required this.mode})
-      : super._();
+      _$UrlLaunchDataCopyWithImpl<UrlLaunchData>(
+          this as UrlLaunchData, _$identity);
 
   @override
-  final String urlString;
-  @override
-  final LaunchMode mode;
-
-  @override
-  String toString() {
-    return 'UrlLaunchData(urlString: $urlString, mode: $mode)';
-  }
-
-  @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$UrlLaunchDataImpl &&
+            other is UrlLaunchData &&
             (identical(other.urlString, urlString) ||
                 other.urlString == urlString) &&
             (identical(other.mode, mode) || other.mode == mode));
@@ -129,25 +39,126 @@ class _$UrlLaunchDataImpl extends _UrlLaunchData {
   @override
   int get hashCode => Object.hash(runtimeType, urlString, mode);
 
-  @JsonKey(ignore: true)
+  @override
+  String toString() {
+    return 'UrlLaunchData(urlString: $urlString, mode: $mode)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $UrlLaunchDataCopyWith<$Res> {
+  factory $UrlLaunchDataCopyWith(
+          UrlLaunchData value, $Res Function(UrlLaunchData) _then) =
+      _$UrlLaunchDataCopyWithImpl;
+  @useResult
+  $Res call({String urlString, LaunchMode mode});
+}
+
+/// @nodoc
+class _$UrlLaunchDataCopyWithImpl<$Res>
+    implements $UrlLaunchDataCopyWith<$Res> {
+  _$UrlLaunchDataCopyWithImpl(this._self, this._then);
+
+  final UrlLaunchData _self;
+  final $Res Function(UrlLaunchData) _then;
+
+  /// Create a copy of UrlLaunchData
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? urlString = null,
+    Object? mode = null,
+  }) {
+    return _then(_self.copyWith(
+      urlString: null == urlString
+          ? _self.urlString
+          : urlString // ignore: cast_nullable_to_non_nullable
+              as String,
+      mode: null == mode
+          ? _self.mode
+          : mode // ignore: cast_nullable_to_non_nullable
+              as LaunchMode,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _UrlLaunchData extends UrlLaunchData {
+  const _UrlLaunchData({required this.urlString, required this.mode})
+      : super._();
+
+  @override
+  final String urlString;
+  @override
+  final LaunchMode mode;
+
+  /// Create a copy of UrlLaunchData
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$UrlLaunchDataCopyWith<_UrlLaunchData> get copyWith =>
+      __$UrlLaunchDataCopyWithImpl<_UrlLaunchData>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _UrlLaunchData &&
+            (identical(other.urlString, urlString) ||
+                other.urlString == urlString) &&
+            (identical(other.mode, mode) || other.mode == mode));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, urlString, mode);
+
+  @override
+  String toString() {
+    return 'UrlLaunchData(urlString: $urlString, mode: $mode)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$UrlLaunchDataCopyWith<$Res>
+    implements $UrlLaunchDataCopyWith<$Res> {
+  factory _$UrlLaunchDataCopyWith(
+          _UrlLaunchData value, $Res Function(_UrlLaunchData) _then) =
+      __$UrlLaunchDataCopyWithImpl;
+  @override
+  @useResult
+  $Res call({String urlString, LaunchMode mode});
+}
+
+/// @nodoc
+class __$UrlLaunchDataCopyWithImpl<$Res>
+    implements _$UrlLaunchDataCopyWith<$Res> {
+  __$UrlLaunchDataCopyWithImpl(this._self, this._then);
+
+  final _UrlLaunchData _self;
+  final $Res Function(_UrlLaunchData) _then;
+
+  /// Create a copy of UrlLaunchData
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
-  _$$UrlLaunchDataImplCopyWith<_$UrlLaunchDataImpl> get copyWith =>
-      __$$UrlLaunchDataImplCopyWithImpl<_$UrlLaunchDataImpl>(this, _$identity);
+  $Res call({
+    Object? urlString = null,
+    Object? mode = null,
+  }) {
+    return _then(_UrlLaunchData(
+      urlString: null == urlString
+          ? _self.urlString
+          : urlString // ignore: cast_nullable_to_non_nullable
+              as String,
+      mode: null == mode
+          ? _self.mode
+          : mode // ignore: cast_nullable_to_non_nullable
+              as LaunchMode,
+    ));
+  }
 }
 
-abstract class _UrlLaunchData extends UrlLaunchData {
-  const factory _UrlLaunchData(
-      {required final String urlString,
-      required final LaunchMode mode}) = _$UrlLaunchDataImpl;
-  const _UrlLaunchData._() : super._();
-
-  @override
-  String get urlString;
-  @override
-  LaunchMode get mode;
-  @override
-  @JsonKey(ignore: true)
-  _$$UrlLaunchDataImplCopyWith<_$UrlLaunchDataImpl> get copyWith =>
-      throw _privateConstructorUsedError;
-}
+// dart format on

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -127,7 +127,6 @@ class App extends ConsumerWidget {
       builder: (context, child) {
         return Navigator(
           key: ref.watch(navigatorKeyProvider),
-          onPopPage: (route, dynamic _) => false,
           pages: [
             MaterialPage<Widget>(
               child: Stack(

--- a/lib/presentation/common/components/buttons.dart
+++ b/lib/presentation/common/components/buttons.dart
@@ -53,8 +53,8 @@ class AppButtons {
     return OutlinedButton(
       onPressed: onPressed,
       style: OutlinedButton.styleFrom(
-        backgroundColor: isSelected 
-            ? AppColors.green.withOpacity(0.3)
+        backgroundColor: isSelected
+            ? AppColors.green.withValues(alpha: 0.3)
             : Colors.transparent,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(30),

--- a/lib/presentation/common/components/buttons.dart
+++ b/lib/presentation/common/components/buttons.dart
@@ -29,7 +29,7 @@ class AppButtons {
     return TextButton(
       onPressed: onPressed,
       style: ButtonStyle(
-        backgroundColor: MaterialStateProperty.all(
+        backgroundColor: WidgetStateProperty.all(
           isSelected ? AppColors.green : Colors.transparent,
         ),
       ),

--- a/lib/presentation/common/components/custom_about_dialog.dart
+++ b/lib/presentation/common/components/custom_about_dialog.dart
@@ -9,12 +9,12 @@ class CustomAboutDialog extends StatelessWidget {
   final String applicationLegalese;
 
   const CustomAboutDialog({
-    Key? key,
+    super.key,
     required this.applicationName,
     required this.applicationVersion,
     required this.applicationIcon,
     required this.applicationLegalese,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/presentation/diagnosis/depression/depression_type_diagnosis_page.dart
+++ b/lib/presentation/diagnosis/depression/depression_type_diagnosis_page.dart
@@ -7,8 +7,6 @@ import 'package:mood_trend_flutter/presentation/common/theme/app_text_styles.dar
 import 'package:mood_trend_flutter/presentation/diagnosis/providers/diagnosis_providers.dart';
 import 'package:mood_trend_flutter/presentation/diagnosis/self_input_page.dart';
 import 'package:mood_trend_flutter/utils/app_colors.dart';
-import 'package:mood_trend_flutter/utils/navigation_utils.dart';
-import 'package:mood_trend_flutter/utils/page_navigator.dart';
 import 'depression_type_table_page.dart';
 import 'entity/depression_worksheet.dart';
 

--- a/lib/presentation/diagnosis/depression/depression_type_table_page.dart
+++ b/lib/presentation/diagnosis/depression/depression_type_table_page.dart
@@ -50,7 +50,7 @@ class DepressionTypeTablePage extends ConsumerWidget with ErrorHandlerMixin {
                   width: 350,
                   decoration: BoxDecoration(
                     borderRadius: BorderRadius.circular(10),
-                    color: AppColors.green.withOpacity(0.4),
+                    color: AppColors.green.withValues(alpha: 0.4),
                   ),
                   child: Column(children: [
                     TableCell(

--- a/lib/presentation/diagnosis/manic/manic_type_diagnosis_page.dart
+++ b/lib/presentation/diagnosis/manic/manic_type_diagnosis_page.dart
@@ -24,7 +24,7 @@ class ManicTypeDiagnosisPage extends ConsumerWidget {
     ButtonStyle buttonStyle(ManicType manicType) {
       return OutlinedButton.styleFrom(
         backgroundColor: selectedManicType == manicType
-            ? AppColors.green.withOpacity(0.3)
+            ? AppColors.green.withValues(alpha: 0.3)
             : Colors.transparent,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(30),

--- a/lib/presentation/diagnosis/manic/manic_type_table_page.dart
+++ b/lib/presentation/diagnosis/manic/manic_type_table_page.dart
@@ -51,7 +51,7 @@ class ManicTypeTablePage extends ConsumerWidget with ErrorHandlerMixin {
                   width: 350,
                   decoration: BoxDecoration(
                     borderRadius: BorderRadius.circular(10),
-                    color: AppColors.green.withOpacity(0.4),
+                    color: AppColors.green.withValues(alpha: 0.4),
                   ),
                   child: Column(children: [
                     TableCell(

--- a/lib/presentation/diagnosis/register_diagnosis_page.dart
+++ b/lib/presentation/diagnosis/register_diagnosis_page.dart
@@ -128,7 +128,7 @@ class RegisterDiagnosisPage extends ConsumerWidget with ErrorHandlerMixin {
                     width: 350,
                     decoration: BoxDecoration(
                       borderRadius: BorderRadius.circular(10),
-                      color: AppColors.green.withOpacity(0.4),
+                      color: AppColors.green.withValues(alpha: 0.4),
                     ),
                     child: Column(
                       children:

--- a/lib/presentation/diagnosis/register_diagnosis_page.dart
+++ b/lib/presentation/diagnosis/register_diagnosis_page.dart
@@ -12,8 +12,6 @@ import 'package:mood_trend_flutter/presentation/common/theme/app_text_styles.dar
 import 'package:mood_trend_flutter/presentation/diagnosis/manic/register_manic_entity_provider.dart';
 import 'package:mood_trend_flutter/presentation/diagnosis/providers/diagnosis_providers.dart';
 import 'package:mood_trend_flutter/presentation/diagnosis/table_page.dart';
-import 'package:mood_trend_flutter/utils/navigation_utils.dart';
-import 'package:mood_trend_flutter/utils/page_navigator.dart';
 
 import '../../utils/app_colors.dart';
 import 'components/worksheet_table_cell.dart';

--- a/lib/presentation/diagnosis/table_page.dart
+++ b/lib/presentation/diagnosis/table_page.dart
@@ -151,7 +151,7 @@ class TablePage extends ConsumerWidget {
                         width: 350,
                         decoration: BoxDecoration(
                           borderRadius: BorderRadius.circular(10),
-                          color: AppColors.green.withOpacity(0.4),
+                          color: AppColors.green.withValues(alpha: 0.4),
                         ),
                         child: Column(
                           children: buildTableCells(

--- a/lib/presentation/diagnosis/table_page.dart
+++ b/lib/presentation/diagnosis/table_page.dart
@@ -9,7 +9,6 @@ import 'package:mood_trend_flutter/presentation/common/navigation/navigation_ser
 import 'package:mood_trend_flutter/presentation/common/theme/app_text_styles.dart';
 import 'package:mood_trend_flutter/presentation/diagnosis/providers/diagnosis_providers.dart';
 import 'package:mood_trend_flutter/utils/app_colors.dart';
-import 'package:mood_trend_flutter/utils/navigation_utils.dart';
 import 'package:mood_trend_flutter/utils/page_navigator.dart';
 
 import '../../application/diagnosis/states/subscribe_mood_work_sheet_provider.dart';

--- a/lib/presentation/graph/home_page.dart
+++ b/lib/presentation/graph/home_page.dart
@@ -246,7 +246,7 @@ class HomePage extends ConsumerWidget {
                         xValueMapper: (MoodPoint value, _) =>
                             value.moodDate.toDateOnly(),
                         yValueMapper: (MoodPoint value, _) => value.point,
-                        color: AppColors.green.withOpacity(0.5),
+                        color: AppColors.green.withValues(alpha: 0.5),
                         markerSettings: const MarkerSettings(isVisible: true),
                         splineType: SplineType.monotonic,
                       ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -106,26 +106,26 @@ packages:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: "339086358431fa15d7eca8b6a36e5d783728cf025e559b834f4609a1fcfb7b0a"
+      sha256: b9e4fda21d846e192628e7a4f6deda6888c36b5b69ba02ff291a01fd529140f0
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.4.4"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "028819cfb90051c6b5440c7e574d1896f8037e3c96cf17aaeb054c9311cfbf4d"
+      sha256: "058fe9dce1de7d69c4b84fada934df3e0153dd000758c4d65964d0166779aa99"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.13"
+    version: "2.4.15"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      sha256: f8126682b87a7282a339b871298cc12009cb67109cfa1614d6436fb0289193e0
+      sha256: "22e3aa1c80e0ada3722fe5b63fd43d9c8990759d0a2cf489c8c5d7b2bdebc021"
       url: "https://pub.dev"
     source: hosted
-    version: "7.3.2"
+    version: "8.0.0"
   built_collection:
     dependency: transitive
     description:
@@ -478,18 +478,18 @@ packages:
     dependency: "direct main"
     description:
       name: freezed
-      sha256: "44c19278dd9d89292cf46e97dc0c1e52ce03275f40a97c5a348e802a924bf40e"
+      sha256: "6022db4c7bfa626841b2a10f34dd1e1b68e8f8f9650db6112dcdeeca45ca793c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.7"
+    version: "3.0.6"
   freezed_annotation:
     dependency: "direct main"
     description:
       name: freezed_annotation
-      sha256: c2e2d632dd9b8a2b7751117abcfc2b4888ecfe181bd9fca7170d9ef02e595fe2
+      sha256: c87ff004c8aa6af2d531668b46a4ea379f7191dc6dfa066acd53d506da6e044b
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.4"
+    version: "3.0.0"
   frontend_server_client:
     dependency: transitive
     description:
@@ -646,10 +646,10 @@ packages:
     dependency: "direct dev"
     description:
       name: json_serializable
-      sha256: ea1432d167339ea9b5bb153f0571d0039607a873d6e04e0117af043f14a1fd4b
+      sha256: c50ef5fc083d5b5e12eef489503ba3bf5ccc899e487d691584699b4bdefeea8c
       url: "https://pub.dev"
     source: hosted
-    version: "6.8.0"
+    version: "6.9.5"
   leak_tracker:
     dependency: transitive
     description:
@@ -939,18 +939,18 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "14658ba5f669685cd3d63701d01b31ea748310f7ab854e471962670abcf57832"
+      sha256: "35c8150ece9e8c8d263337a265153c3329667640850b9304861faea59fc98f6b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
+    version: "2.0.0"
   source_helper:
     dependency: transitive
     description:
       name: source_helper
-      sha256: "6adebc0006c37dd63fe05bca0a929b99f06402fc95aa35bf36d67f5c06de01fd"
+      sha256: "86d247119aedce8e63f4751bd9626fc9613255935558447569ad42f9f5b48b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.4"
+    version: "1.3.5"
   source_span:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,8 +15,8 @@ dependencies:
   firebase_core: ^3.8.0
   firebase_auth: ^5.3.3
   flutter_riverpod: ^2.4.4
-  freezed: ^2.4.5
-  freezed_annotation: ^2.4.1
+  freezed: ^3.0.6
+  freezed_annotation: ^3.0.0
   package_info: ^2.0.2
   cloud_firestore: ^5.5.0
   hooks_riverpod: ^2.4.4
@@ -46,7 +46,7 @@ dev_dependencies:
     sdk: flutter
 
   flutter_lints: ^5.0.0
-  build_runner: ^2.4.8
+  build_runner: ^2.4.15
   json_serializable: ^6.7.1
 
 flutter_native_splash:


### PR DESCRIPTION
## 関連する Design Doc (Issue 番号)

close [#129](https://github.com/Mood-Trend/mood-trend-flutter/issues/129)


## 変更点

### やったこと

- リントエラー解消のための全体的なコード修正
- 以下のリントに対応した修正を実施
  - `Navigator.onPopPage` の削除（Flutter 3.16.0-17.0.pre 以降非推奨）
  - `MaterialStateProperty` → `WidgetStateProperty` へ移行（Flutter 3.16.0-17.0.pre 以降非推奨）
  - `super.key` への簡略化（`use_super_parameters`）
  - `Color.withOpacity` → `Color.withValues(alpha: ...)` へリファクタリング
  - freezed クラス定義を `abstract class` に変更（Dart 3 によるリント対応）
  - 未使用の import を削除
- 依存パッケージ（freezed, build_runner 等）のバージョンを最新化
- コード生成ファイルの再生成（`build_runner build` 実行済）

### やってないこと

- 機能の追加やUIの大きな変更は行っていません


## スクリーンショット（該当する場合）

- なし  
（UIへの直接的な変更はありません）


## レビューのポイント

- 各リント対応の意図と影響範囲に問題がないか
- freezed定義変更によるモデルへの影響がないか
- `WidgetStateProperty` 置換後の挙動に問題がないか
- `onPopPage` 削除によるナビゲーション影響の有無


## 追加の注意点

- 現在、以下の理由により iOS シミュレータでのビルドができない状態です：
```
Expected ios/Runner.xcodeproj/project.pbxproj
but this file is missing.
No application found for TargetPlatform.ios.
Is your project missing an
ios/Runner/Info.plist?
Consider running "flutter create ." to create
```

- また以下の警告は修正が膨大になるため対応していません。
 ```
 Don't use 'BuildContext's across async gaps. Try rewriting the code to not use the 'BuildContext', or guard the use with a 'mounted' check.
 ```


