### PR TITLE
feat: グラフタップ時にチップを表示する機能を追加 #105 

### DIFF
--- a/lib/presentation/common/components/custom_tooltip_behavior.dart
+++ b/lib/presentation/common/components/custom_tooltip_behavior.dart
@@ -11,11 +11,6 @@ TooltipBehavior createCustomTooltipBehavior(BuildContext context) {
     enable: true,
     canShowMarker: false,
     color: AppColors.green,
-    textStyle: TextStyle(
-      fontSize: 16,
-      fontWeight: FontWeight.bold,
-      color: AppColors.white,
-    ),
     // builder プロパティを追加
     builder: (dynamic data, dynamic point, dynamic series, int pointIndex,
         int seriesIndex) {

--- a/lib/presentation/common/components/custom_tooltip_behavior.dart
+++ b/lib/presentation/common/components/custom_tooltip_behavior.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:mood_trend_flutter/domain/mood_point.dart';
+import 'package:mood_trend_flutter/generated/l10n.dart';
+import 'package:mood_trend_flutter/presentation/common/theme/app_text_styles.dart';
+import 'package:mood_trend_flutter/utils/app_colors.dart';
+import 'package:syncfusion_flutter_charts/charts.dart';
+
+TooltipBehavior createCustomTooltipBehavior(BuildContext context) {
+  return TooltipBehavior(
+    enable: true,
+    canShowMarker: false,
+    color: AppColors.green,
+    textStyle: TextStyle(
+      fontSize: 16,
+      fontWeight: FontWeight.bold,
+      color: AppColors.white,
+    ),
+    // builder プロパティを追加
+    builder: (dynamic data, dynamic point, dynamic series, int pointIndex,
+        int seriesIndex) {
+      // data から必要な情報を取得
+      final moodPoint = data as MoodPoint;
+      // 日付をフォーマット
+      final formattedDate =
+          DateFormat('MM/dd', Localizations.localeOf(context).languageCode);
+      // 動的なヘッダー文字列を作成
+      final dynamicHeader = formattedDate.format(moodPoint.moodDate);
+
+      // ツールチップに表示する内容を構築
+      return Container(
+        padding: const EdgeInsets.all(8.0),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              dynamicHeader,
+              style: AppTextStyles.selectedButtonText,
+            ),
+            const SizedBox(height: 4),
+            Text(
+              '${S.of(context).moodValue}: ${moodPoint.point}',
+              style: AppTextStyles.selectedButtonText,
+            ),
+            Text(
+              '${S.of(context).plannedVolume}: ${moodPoint.plannedVolume}',
+              style: AppTextStyles.selectedButtonText,
+            ),
+          ],
+        ),
+      );
+    },
+  );
+}

--- a/lib/presentation/common/components/custom_tooltip_behavior.dart
+++ b/lib/presentation/common/components/custom_tooltip_behavior.dart
@@ -12,8 +12,7 @@ TooltipBehavior createCustomTooltipBehavior(BuildContext context) {
     canShowMarker: false,
     color: AppColors.green,
     // builder プロパティを追加
-    builder: (dynamic data, dynamic point, dynamic series, int pointIndex,
-        int seriesIndex) {
+    builder: (dynamic data, __, ___, ____, _____) {
       // data から必要な情報を取得
       final moodPoint = data as MoodPoint;
       // 日付をフォーマット

--- a/lib/presentation/graph/home_page.dart
+++ b/lib/presentation/graph/home_page.dart
@@ -7,6 +7,7 @@ import 'package:mood_trend_flutter/presentation/common/components/async_value_ha
 import 'package:mood_trend_flutter/presentation/common/components/loading.dart';
 import 'package:mood_trend_flutter/presentation/common/setting_page.dart';
 import 'package:mood_trend_flutter/presentation/common/theme/app_text_styles.dart';
+import 'package:mood_trend_flutter/presentation/common/components/custom_tooltip_behavior.dart';
 import 'package:mood_trend_flutter/utils/datetime_extension.dart';
 import 'package:mood_trend_flutter/utils/page_navigator.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -66,53 +67,6 @@ class HomePage extends ConsumerWidget {
 
     // コーチマーク用のターゲット
     final GlobalKey floatingActionButtonKey = GlobalKey();
-
-    // ツールチップの設定
-    final TooltipBehavior tooltipBehavior = TooltipBehavior(
-      enable: true,
-      canShowMarker: false,
-      color: AppColors.green,
-      textStyle: TextStyle(
-        fontSize: 16,
-        fontWeight: FontWeight.bold,
-        color: AppColors.white,
-      ),
-      // builder プロパティを追加
-      builder: (dynamic data, dynamic point, dynamic series, int pointIndex,
-          int seriesIndex) {
-        // data から必要な情報を取得
-        final moodPoint = data as MoodPoint;
-        // 日付をフォーマット
-        final formattedDate =
-            DateFormat('MM/dd', Localizations.localeOf(context).languageCode);
-        // 動的なヘッダー文字列を作成
-        final dynamicHeader = formattedDate.format(moodPoint.moodDate);
-
-        // ツールチップに表示する内容を構築
-        return Container(
-          padding: const EdgeInsets.all(8.0),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                dynamicHeader,
-                style: AppTextStyles.selectedButtonText,
-              ),
-              const SizedBox(height: 4),
-              Text(
-                '${S.of(context).moodValue}: ${moodPoint.point}',
-                style: AppTextStyles.selectedButtonText,
-              ),
-              Text(
-                '${S.of(context).plannedVolume}: ${moodPoint.plannedVolume}',
-                style: AppTextStyles.selectedButtonText,
-              ),
-            ],
-          ),
-        );
-      },
-    );
 
     // コーチマークのセットアップ
     Future<void> showCoachMark() async {
@@ -177,6 +131,10 @@ class HomePage extends ConsumerWidget {
             selectedTerm == term ? AppColors.green : Colors.transparent,
       );
     }
+
+    // ツールチップの設定
+    final TooltipBehavior tooltipBehavior =
+        createCustomTooltipBehavior(context);
 
     return Scaffold(
       backgroundColor: AppColors.white,

--- a/lib/presentation/graph/home_page.dart
+++ b/lib/presentation/graph/home_page.dart
@@ -66,6 +66,63 @@ class HomePage extends ConsumerWidget {
     // コーチマーク用のターゲット
     final GlobalKey floatingActionButtonKey = GlobalKey();
 
+    // ツールチップの設定
+    final TooltipBehavior tooltipBehavior = TooltipBehavior(
+      enable: true,
+      canShowMarker: false,
+      color: AppColors.green,
+      textStyle: TextStyle(
+        fontSize: 16,
+        fontWeight: FontWeight.bold,
+        color: AppColors.white,
+      ),
+      // builder プロパティを追加
+      builder: (dynamic data, dynamic point, dynamic series, int pointIndex,
+          int seriesIndex) {
+        // data から必要な情報を取得
+        final moodPoint = data as MoodPoint;
+        // 日付をフォーマット
+        final formattedDate =
+            DateFormat('MM/dd', Localizations.localeOf(context).languageCode);
+        // 動的なヘッダー文字列を作成
+        final dynamicHeader = formattedDate.format(moodPoint.moodDate);
+
+        // ツールチップに表示する内容を構築
+        return Container(
+          padding: const EdgeInsets.all(8.0),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                dynamicHeader,
+                style: TextStyle(
+                  fontWeight: FontWeight.bold,
+                  fontSize: 14,
+                  color: AppColors.white,
+                ),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                '${S.of(context).moodValue}: ${moodPoint.point}',
+                style: TextStyle(
+                  fontSize: 12,
+                  color: AppColors.white,
+                ),
+              ),
+              Text(
+                '${S.of(context).plannedVolume}: ${moodPoint.plannedVolume}',
+                style: TextStyle(
+                  fontSize: 12,
+                  color: AppColors.white,
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+
     // コーチマークのセットアップ
     Future<void> showCoachMark() async {
       final prefs = await SharedPreferences.getInstance();
@@ -185,6 +242,7 @@ class HomePage extends ConsumerWidget {
                   padding: const EdgeInsets.fromLTRB(16, 0, 16, 32),
                   child: SfCartesianChart(
                     key: ValueKey(visibleMinDate),
+                    tooltipBehavior: tooltipBehavior,
                     zoomPanBehavior: ZoomPanBehavior(
                       enablePanning: true, // スクロール（パンニング）を有効化
                       zoomMode: ZoomMode.x, // X軸方向のズーム/パンのみ有効化

--- a/lib/presentation/graph/home_page.dart
+++ b/lib/presentation/graph/home_page.dart
@@ -6,6 +6,7 @@ import 'package:mood_trend_flutter/generated/l10n.dart';
 import 'package:mood_trend_flutter/presentation/common/components/async_value_handler.dart';
 import 'package:mood_trend_flutter/presentation/common/components/loading.dart';
 import 'package:mood_trend_flutter/presentation/common/setting_page.dart';
+import 'package:mood_trend_flutter/presentation/common/theme/app_text_styles.dart';
 import 'package:mood_trend_flutter/utils/datetime_extension.dart';
 import 'package:mood_trend_flutter/utils/page_navigator.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -96,26 +97,16 @@ class HomePage extends ConsumerWidget {
             children: [
               Text(
                 dynamicHeader,
-                style: TextStyle(
-                  fontWeight: FontWeight.bold,
-                  fontSize: 14,
-                  color: AppColors.white,
-                ),
+                style: AppTextStyles.selectedButtonText,
               ),
               const SizedBox(height: 4),
               Text(
                 '${S.of(context).moodValue}: ${moodPoint.point}',
-                style: TextStyle(
-                  fontSize: 12,
-                  color: AppColors.white,
-                ),
+                style: AppTextStyles.selectedButtonText,
               ),
               Text(
                 '${S.of(context).plannedVolume}: ${moodPoint.plannedVolume}',
-                style: TextStyle(
-                  fontSize: 12,
-                  color: AppColors.white,
-                ),
+                style: AppTextStyles.selectedButtonText,
               ),
             ],
           ),

--- a/lib/presentation/graph/home_page.dart
+++ b/lib/presentation/graph/home_page.dart
@@ -6,7 +6,6 @@ import 'package:mood_trend_flutter/generated/l10n.dart';
 import 'package:mood_trend_flutter/presentation/common/components/async_value_handler.dart';
 import 'package:mood_trend_flutter/presentation/common/components/loading.dart';
 import 'package:mood_trend_flutter/presentation/common/setting_page.dart';
-import 'package:mood_trend_flutter/presentation/common/theme/app_text_styles.dart';
 import 'package:mood_trend_flutter/presentation/common/components/custom_tooltip_behavior.dart';
 import 'package:mood_trend_flutter/utils/datetime_extension.dart';
 import 'package:mood_trend_flutter/utils/page_navigator.dart';


### PR DESCRIPTION
## 関連する Design Doc (Issue 番号)

- [Design Doc] グラフタップ時にチップを表示 #105

## 変更点

- グラフタップ時にチップが表示されるようにした
- /lib/presentation/common/components/custom_tooltip_behavior.dartを作成し、実装した

### やったこと

- /lib/presentation/common/components/custom_tooltip_behavior.dartを作成した
- ToolTipBehaviorを定義した

### やってないこと

- チップで表示される日付の中央揃え
- チップで表示される気分値が正の場合の + 表示
- チップ専用のTextStyleの定義
- 実機での確認

## スクリーンショット（該当する場合）

https://github.com/user-attachments/assets/804e7a8c-3eeb-4662-b34e-6c739d394a43

## レビューのポイント

- アニメーションの挙動
- TextStyle

## Reference

- https://pub.dev/packages/syncfusion_flutter_charts